### PR TITLE
feat: remove unused CF tunnel secret variable and add gate-peterovi

### DIFF
--- a/.github/workflows/tofu-cloudflare.yml
+++ b/.github/workflows/tofu-cloudflare.yml
@@ -50,7 +50,6 @@ env:
   TF_VAR_cloudflare_account_id: ${{ secrets.TF_VAR_CLOUDFLARE_ACCOUNT_ID }}
   TF_VAR_cloudflare_zero_trust_access_identity_provider_google_oauth_client_id: ${{ secrets.TF_VAR_CLOUDFLARE_ZERO_TRUST_ACCESS_IDENTITY_PROVIDER_GOOGLE_OAUTH_CLIENT_ID }}
   TF_VAR_cloudflare_zero_trust_access_identity_provider_google_oauth_client_secret: ${{ secrets.TF_VAR_CLOUDFLARE_ZERO_TRUST_ACCESS_IDENTITY_PROVIDER_GOOGLE_OAUTH_CLIENT_SECRET }}
-  TF_VAR_cloudflare_zero_trust_tunnel_cloudflared_tunnel_secret: ${{ secrets.TF_VAR_CLOUDFLARE_ZERO_TRUST_TUNNEL_CLOUDFLARED_TUNNEL_SECRET }}
   TF_VAR_opentofu_encryption_passphrase: ${{ secrets.TF_VAR_OPENTOFU_ENCRYPTION_PASSPHRASE }}
   TOFU_WORKING_DIRECTORY: opentofu/cloudflare
   # keep-sorted end

--- a/gh-repo-defaults/my-defaults/.github/workflows/renovate.yml
+++ b/gh-repo-defaults/my-defaults/.github/workflows/renovate.yml
@@ -58,9 +58,6 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}
     permissions: write-all
     steps:
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
       - uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
         id: app-token
         with:

--- a/opentofu/.env.yaml
+++ b/opentofu/.env.yaml
@@ -9,8 +9,6 @@ AWS_ACCESS_KEY_ID: ENC[AES256_GCM,data:gwZbE8JGtSnp6A2XGmPR+Ao7jcuF+Ax+JziIy+XmE
 CLOUDFLARE_API_TOKEN: ENC[AES256_GCM,data:cJlGWy+IOxC/WsWhP8q9tuU35ye0TT/QdGpjXl1dc1JNbaEuHu2L4A==,iv:soMqujTzUdqJMpZ3TBPuGIHD8G+1n529d85mWzdYcTk=,tag:j5M88AXxLaVP9Nxe/6gmXg==,type:str]
 #ENC[AES256_GCM,data:QoxBoiSjGHjCK2w5+l61ZBZKhJcREg==,iv:Zl6gEVGOvlp4XAaTzO+bKcFXEGLsBSNzYvr7w6N+6lo=,tag:qoFe14nfgUg16UqyOFmSdQ==,type:comment]
 TF_VAR_cloudflare_account_id: ENC[AES256_GCM,data:PfnVU8TWaYwiHZXaoNPGLrERYFZmhsuhMdEXHFcsk6g=,iv:kpTOB3Vzy+jHpbK4812b7cAjHs7WOFAdPYp/Dr3+3kA=,tag:G6HvvSrxwoJG71aMA8Qb+w==,type:str]
-#ENC[AES256_GCM,data:f3wmRhUaNtyhCTnq8UaPWpAPj9w/MWzTA64l88n0AAy2NEGpwdvG1bQ8iUQzOv0ULxImF0sULw==,iv:1pUcDCS3DnZ3CA91C9S36wXREQeyhs5g3oCGRX7MI3k=,tag:6jnu/GtUGGYEDCnS2hGUxA==,type:comment]
-TF_VAR_cloudflare_zero_trust_tunnel_cloudflared_tunnel_secret: ENC[AES256_GCM,data:3aSxHe1Ot7DJmSTETd4fc1VxNFozOnaXjdhaSeArrIk9KcvKAcyT1hdf27g=,iv:TeRlp9Ikkgwwu8IvfSfNZZU2njyRWfsdTC2w5pQAlHs=,tag:59k3F2mI/WPTj/D53qP2gA==,type:str]
 #ENC[AES256_GCM,data:m92MMDnSgRb3oBZhplDOwYbq8KSqAsGUVdkU3CGb4/66dVwOiRVhbq/fsoFndaG94OnTFpTNReoro7z0mo9SUVyUQMsM6ZYB,iv:1vuPSByUjo8zlJ8kghqO8WEvEe4+jRtzoM1+T0HZP3o=,tag:7udzjP/8egxkNg7quPS7kA==,type:comment]
 TF_VAR_cloudflare_zero_trust_access_identity_provider_google_oauth_client_id: ENC[AES256_GCM,data:bHwfSCb8phZFDyLmRfd2eLKJXjZzTUGYy00Ng/LnNkP4Ew0nA5mTqmYZLTan/OPhaAsZ7UwRaaxS3CGU2RdiaV2GtSDVKTB3BA==,iv:tbv9TkdrDY+QxZmorYfILQ7fqbzPVTRtiEHOnIXZEW8=,tag:U189qAzz6N6F5TZrm62jjw==,type:str]
 #ENC[AES256_GCM,data:ttDej4wbdGprfj5/gWZuE0Xf1mIxXrGJOON3UDC1Vhjh1qiQkVlsH3gQIgZsDtYQsPh7V4l3Z1Q5Cb6TxSEyqE1S74CyeQgpgEld8w==,iv:BsHcZkB6wXaCTf8YxxAzKd70yjYe8xSk54m7WmR2AUg=,tag:w6qzhH2WLIhNfqN6j6Un5A==,type:comment]
@@ -33,7 +31,7 @@ sops:
         YnhhMmJUdGlBODBCKytDQUh0WkNSVGcKJVvSqJyh9J0tKIFkgOn+hkzg1BaL+SpH
         wNAFCpA3oiwfzYwbUtAH/B3nB3rqb8JG81HhE2+XcygSZ+ZfdKM7ew==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2025-05-10T07:11:45Z"
-  mac: ENC[AES256_GCM,data:/JcmoB8E2FcYUjmuLp+sTX+g2vUGVaDjGFgtOMbhvt61F4hcsyviT60Q9REZzlEjCiCMuSbPpqWveD5zTk2ROJIHwmP0YSGlsBSEpY4ZEiVADw4OtP4YkYtN2RGSdcJf6CR1B20AZs5t0C9AQsnXKuy6jIiUuyxH+i2I8126yfo=,iv:kiVO05/JCzLxEjk7FOkhKKN8n2f3zGHmTTUKGsTw39M=,tag:niHFNkCUoBu84GWYEjfTag==,type:str]
+  lastmodified: "2025-06-19T05:08:27Z"
+  mac: ENC[AES256_GCM,data:YL2faGzdyOhb/oUjGlN4CHNqe5K55kkl0PpFm0U4SLtRAD3OqKqNFE6YWw3N4RjoAe9ZmzQPGj49+OWNg58bN4nj/WGJ30nonqLEB20HKC512l6LnVdNL0rHxqSIbGOfMUsG997fLhmNwIPUSrFb/V52dY3uXW5qeyh3OLk3B3I=,iv:7dI8cJPb6dgwfPVGkWendXCUbaXchrvhIB23pfvwtMo=,tag:a+DB/hGk9XZDLoH7O03Slg==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.10.2

--- a/opentofu/cloudflare/main.tf
+++ b/opentofu/cloudflare/main.tf
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = "5.5.0"
+      version = "5.4.0"
     }
     http = {
       source  = "hashicorp/http"

--- a/opentofu/cloudflare/variables.tf
+++ b/opentofu/cloudflare/variables.tf
@@ -17,12 +17,6 @@ variable "cloudflare_zero_trust_access_identity_provider_google_oauth_client_sec
   type        = string
 }
 
-variable "cloudflare_zero_trust_tunnel_cloudflared_tunnel_secret" {
-  description = "Cloudflare Zero Trust Tunnel Cloudflared Tunnel Secret"
-  sensitive   = true
-  type        = string
-}
-
 variable "opentofu_encryption_passphrase" {
   description = "OpenTofu encryption passphrase"
   sensitive   = true

--- a/opentofu/cloudflare/zerotrust.tf
+++ b/opentofu/cloudflare/zerotrust.tf
@@ -10,8 +10,8 @@ locals {
     }
   ]
   cloudflare_zero_trust_tunnels_applications = {
+    # keep-sorted start block=yes
     "gate" = {
-      tunnel_secret = var.cloudflare_zero_trust_tunnel_cloudflared_tunnel_secret
       applications = {
         # keep-sorted start block=yes
         "gate" = {
@@ -41,8 +41,22 @@ locals {
         # keep-sorted end
       }
     },
+    "gate-peterovi" = {
+      applications = {
+        # keep-sorted start block=yes
+        "gate-peterovi" = {
+          logo_url = "https://raw.githubusercontent.com/openwrt/branding/master/logo/openwrt_logo_blue_and_dark_blue.png"
+          service  = "https://127.0.0.1"
+          tags     = ["lan", "router", "wan"]
+        }
+        "gate-ssh-peterovi" = {
+          service = "ssh://127.0.0.1:22"
+          tags    = ["lan", "router", "ssh", "wan"]
+        }
+        # keep-sorted end
+      }
+    },
     "raspi" = {
-      tunnel_secret = var.cloudflare_zero_trust_tunnel_cloudflared_tunnel_secret
       applications = {
         # keep-sorted start block=yes
         "alloy-rpi" = {
@@ -103,6 +117,7 @@ locals {
         # keep-sorted end
       }
     }
+    # keep-sorted end
   }
 }
 
@@ -170,11 +185,10 @@ resource "cloudflare_zero_trust_access_policy" "allow_all" {
 
 # Create cloudflare_zero_trust_tunnel_cloudflared resources for each tunnel in the map
 resource "cloudflare_zero_trust_tunnel_cloudflared" "tunnels" {
-  for_each      = local.cloudflare_zero_trust_tunnels_applications
-  account_id    = var.cloudflare_account_id
-  name          = each.key
-  config_src    = "cloudflare"
-  tunnel_secret = each.value.tunnel_secret
+  for_each   = local.cloudflare_zero_trust_tunnels_applications
+  account_id = var.cloudflare_account_id
+  name       = each.key
+  config_src = "cloudflare"
 }
 
 resource "cloudflare_zero_trust_tunnel_cloudflared_config" "configs" {


### PR DESCRIPTION
Remove the unused Cloudflare tunnel secret variable and introduce a new application configuration for "gate-peterovi" in the Zero Trust setup.

- Eliminated the `TF_VAR_cloudflare_zero_trust_tunnel_cloudflared_tunnel_secret` variable from the workflow and environment files.

- Removed the corresponding variable definition from `variables.tf`.

- Updated the `zerotrust.tf` file to include a new application configuration for "gate-peterovi" with specific service details.

- Adjusted the Cloudflare provider version from "5.5.0" to "5.4.0" in `main.tf`.