### PR TITLE
fix: update SubjectClaimFilters and add role assumption for GitHub Actions

### DIFF
--- a/.github/workflows/aws-cloudformation-gh-action.yml
+++ b/.github/workflows/aws-cloudformation-gh-action.yml
@@ -33,9 +33,9 @@ jobs:
           no-fail-on-empty-changeset: 1
           capabilities: CAPABILITY_NAMED_IAM
           parameter-overrides: >-
-            SubjectClaimFilters="repo:ruzickap/my-git-projects:*,repo:ruzickap/ruzickap.github.io:*,repo:McK-Internal/ruzickap:*,repo:ruzickap/gha-test:*,repo:ruzickap/malware-cryptominer-container:*"
-          tags: '[
-            {"Key": "Owner", "Value": "petr.ruzicka@gmail.com"},
-            {"Key": "Environment", "Value": "dev"},
-            {"Key": "Source", "Value": "${{ github.server_url }}/${{ github.repository }}/blob/main/cloudformation/gh-action-iam-role-oidc.yaml"}
+            SubjectClaimFilters="repo:ruzickap/my-git-projects:*,repo:ruzickap/ruzickap.github.io:*,repo:McK-Internal/ruzickap:*,repo:ruzickap/gha-test:*,repo:ruzickap/malware-cryptominer-container:*,repo:ruzickap/k8s-multicluster-gitops:*"
+            tags: '[
+              {"Key": "Owner", "Value": "petr.ruzicka@gmail.com"},
+              {"Key": "Environment", "Value": "dev"},
+              {"Key": "Source", "Value": "${{ github.server_url }}/${{ github.repository }}/blob/main/cloudformation/gh-action-iam-role-oidc.yaml"}
             ]'

--- a/cloudformation/gh-action-iam-role-oidc.yaml
+++ b/cloudformation/gh-action-iam-role-oidc.yaml
@@ -66,6 +66,12 @@ Resources:
               AWS: !GetAtt User.Arn
             Action:
               - "sts:AssumeRole"
+          - Sid: AllowSelfToAssumeRole
+            Effect: Allow
+            Principal:
+              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:role/GitHubOidcFederatedRole"
+            Action:
+              - "sts:AssumeRole"
       Description: Service Role for use in GitHub Actions
       RoleName: GitHubOidcFederatedRole
       MaxSessionDuration: 36000


### PR DESCRIPTION
Update the SubjectClaimFilters to include an additional repository and add a new role assumption for GitHub Actions to enhance security and functionality.

- Modified the SubjectClaimFilters to include `repo:ruzickap/k8s-multicluster-gitops:*`.

- Added a new role assumption in the IAM role configuration for GitHub Actions.