### PR TITLE
feat: add MX records for mylabs.dev and update TXT record naming convention

### DIFF
--- a/opentofu/cloudflare/README.md
+++ b/opentofu/cloudflare/README.md
@@ -14,3 +14,9 @@ echo "*** ${AWS_ACCESS_KEY_ID} | ${AWS_SECRET_ACCESS_KEY} | ${AWS_S3_ENDPOINT}"
 tofu init
 tofu apply
 ```
+
+Links:
+
+* <https://zonemaster.net/>
+* <https://dnsviz.net/>
+* <https://intodns.com/>


### PR DESCRIPTION
- Introduced MX records for Mailtrap in the Cloudflare zone configuration.
- Updated the naming convention for TXT records to handle empty names correctly.
- Added useful links to the README for DNS testing tools.