### PR TITLE
chore: update actions, pin fnox, enforce SHA pinning, and bump pre-commit hooks

### DIFF
--- a/.github/workflows/aws-cloudformation-gh-action.yml
+++ b/.github/workflows/aws-cloudformation-gh-action.yml
@@ -25,7 +25,7 @@ jobs:
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
 
       - name: 💡 Creates an OIDC provider and role for use with GitHub Actions
-        uses: aws-actions/aws-cloudformation-github-deploy@c6cd26bb03f19ebe84c84e9cdbedfb307bf44fb4 # v2.0.0
+        uses: aws-actions/aws-cloudformation-github-deploy@64bde66a4001208fc0917038be8846d99c9d0585 # v2.1.0
         with:
           name: github-action-iam-role-oidc
           template: ./cloudformation/gh-action-iam-role-oidc.yaml

--- a/.github/workflows/renovate-working-days.yml
+++ b/.github/workflows/renovate-working-days.yml
@@ -58,6 +58,6 @@ jobs:
           private-key: ${{ secrets.MY_RENOVATE_GITHUB_PRIVATE_KEY }}
 
       - name: 💡 Self-hosted Renovate
-        uses: renovatebot/github-action@0b17c4eb901eca44d018fb25744a50a74b2042df # v46.1.4
+        uses: renovatebot/github-action@3633cede7d4d4598438e654eac4a695e46004420 # v46.1.7
         with:
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -55,6 +55,6 @@ jobs:
           private-key: ${{ secrets.MY_RENOVATE_GITHUB_PRIVATE_KEY }}
 
       - name: 💡 Self-hosted Renovate
-        uses: renovatebot/github-action@0b17c4eb901eca44d018fb25744a50a74b2042df # v46.1.4
+        uses: renovatebot/github-action@3633cede7d4d4598438e654eac4a695e46004420 # v46.1.7
         with:
           token: ${{ steps.app-token.outputs.token }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
           - --args=--version "~> 1.11"
 
   - repo: https://github.com/rvben/rumdl-pre-commit
-    rev: v0.1.51
+    rev: v0.1.66
     hooks:
       - id: rumdl-fmt
 
@@ -95,7 +95,7 @@ repos:
       - id: gitleaks
 
   - repo: https://github.com/scop/pre-commit-shfmt
-    rev: v3.12.0-2
+    rev: v3.13.0-1
     hooks:
       - id: shfmt
         args:
@@ -136,7 +136,7 @@ repos:
         stages: [pre-push]
 
   - repo: https://github.com/commit-check/commit-check
-    rev: v2.4.2
+    rev: v2.5.0
     hooks:
       - id: check-message
       - id: check-branch
@@ -160,6 +160,6 @@ repos:
           ]
 
   - repo: https://github.com/rhysd/actionlint
-    rev: v1.7.11
+    rev: v1.7.12
     hooks:
       - id: actionlint-system

--- a/gh-repo-defaults/action/.github/workflows/release-please.yml
+++ b/gh-repo-defaults/action/.github/workflows/release-please.yml
@@ -2,7 +2,6 @@
 # GitHub Actions workflow for automated release management
 # Creates release PRs and GitHub releases when changes are pushed to main
 # https://github.com/googleapis/release-please
-# https://danielscholl-osdu.github.io/osdu-fork-template/workflows/release/
 name: release-please
 
 on:

--- a/gh-repo-defaults/my-defaults/.github/workflows/renovate.yml
+++ b/gh-repo-defaults/my-defaults/.github/workflows/renovate.yml
@@ -55,6 +55,6 @@ jobs:
           private-key: ${{ secrets.MY_RENOVATE_GITHUB_PRIVATE_KEY }}
 
       - name: 💡 Self-hosted Renovate
-        uses: renovatebot/github-action@0b17c4eb901eca44d018fb25744a50a74b2042df # v46.1.4
+        uses: renovatebot/github-action@3633cede7d4d4598438e654eac4a695e46004420 # v46.1.7
         with:
           token: ${{ steps.app-token.outputs.token }}

--- a/opentofu/aws/mise.toml
+++ b/opentofu/aws/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-fnox = "latest"
+fnox = "1.19.0"
 opentofu = "1.11.5"
 
 [plugins]

--- a/opentofu/cloudflare-github/github-repositories.tf
+++ b/opentofu/cloudflare-github/github-repositories.tf
@@ -325,6 +325,13 @@ resource "github_workflow_repository_permissions" "this" {
   repository                       = github_repository.this[each.key].name
 }
 
+resource "github_actions_repository_permissions" "this" {
+  for_each             = local.all_github_repositories
+  allowed_actions      = "all"
+  repository           = github_repository.this[each.key].name
+  sha_pinning_required = true
+}
+
 resource "github_actions_secret" "this" {
   # checkov:skip=CKV_GIT_4:GitHub encrypts secrets automatically when stored via plaintext_value
   for_each = {

--- a/opentofu/cloudflare-github/mise.toml
+++ b/opentofu/cloudflare-github/mise.toml
@@ -1,6 +1,6 @@
 [tools]
 opentofu = "1.11.5"
-fnox = "latest"
+fnox = "1.19.0"
 
 [plugins]
 fnox-env = "https://github.com/jdx/mise-env-fnox"


### PR DESCRIPTION
## Summary

- Bump `aws-cloudformation-github-deploy` from v2.0.0 to v2.1.0
- Bump `renovatebot/github-action` from v46.1.4 to v46.1.7 (across 3 workflow files)
- Pin `fnox` tool version from `latest` to `1.19.0` in both `opentofu/aws/mise.toml` and `opentofu/cloudflare-github/mise.toml`
- Add `github_actions_repository_permissions` resource to enforce `sha_pinning_required = true` on all managed repositories
- Bump pre-commit hooks: `rumdl` v0.1.51 -> v0.1.66, `shfmt` v3.12.0-2 -> v3.13.0-1, `commit-check` v2.4.2 -> v2.5.0, `actionlint` v1.7.11 -> v1.7.12