### PR TITLE
chore: update actions, pre-commit hooks, and add allowed merge methods

### DIFF
--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323 # v47.0.5
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
           files: |
             **/*.md

--- a/.github/workflows/renovate-working-days.yml
+++ b/.github/workflows/renovate-working-days.yml
@@ -58,6 +58,6 @@ jobs:
           private-key: ${{ secrets.MY_RENOVATE_GITHUB_PRIVATE_KEY }}
 
       - name: 💡 Self-hosted Renovate
-        uses: renovatebot/github-action@3633cede7d4d4598438e654eac4a695e46004420 # v46.1.7
+        uses: renovatebot/github-action@eb932558ad942cccfd8211cf535f17ff183a9f74 # v46.1.9
         with:
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -55,6 +55,6 @@ jobs:
           private-key: ${{ secrets.MY_RENOVATE_GITHUB_PRIVATE_KEY }}
 
       - name: 💡 Self-hosted Renovate
-        uses: renovatebot/github-action@3633cede7d4d4598438e654eac4a695e46004420 # v46.1.7
+        uses: renovatebot/github-action@eb932558ad942cccfd8211cf535f17ff183a9f74 # v46.1.9
         with:
           token: ${{ steps.app-token.outputs.token }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
           - --args=--version "~> 1.11"
 
   - repo: https://github.com/rvben/rumdl-pre-commit
-    rev: v0.1.66
+    rev: v0.1.74
     hooks:
       - id: rumdl-fmt
 
@@ -95,7 +95,7 @@ repos:
       - id: gitleaks
 
   - repo: https://github.com/scop/pre-commit-shfmt
-    rev: v3.13.0-1
+    rev: v3.13.1-1
     hooks:
       - id: shfmt
         args:
@@ -128,7 +128,7 @@ repos:
       - id: keep-sorted
 
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: v4.13.9
+    rev: v4.13.10
     hooks:
       - id: commitizen
         stages: [commit-msg]

--- a/gh-repo-defaults/my-defaults/.github/workflows/mega-linter.yml
+++ b/gh-repo-defaults/my-defaults/.github/workflows/mega-linter.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323 # v47.0.5
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
           files: |
             **/*.md

--- a/gh-repo-defaults/my-defaults/.github/workflows/renovate.yml
+++ b/gh-repo-defaults/my-defaults/.github/workflows/renovate.yml
@@ -55,6 +55,6 @@ jobs:
           private-key: ${{ secrets.MY_RENOVATE_GITHUB_PRIVATE_KEY }}
 
       - name: 💡 Self-hosted Renovate
-        uses: renovatebot/github-action@3633cede7d4d4598438e654eac4a695e46004420 # v46.1.7
+        uses: renovatebot/github-action@eb932558ad942cccfd8211cf535f17ff183a9f74 # v46.1.9
         with:
           token: ${{ steps.app-token.outputs.token }}

--- a/opentofu/cloudflare-github/github-repositories.tf
+++ b/opentofu/cloudflare-github/github-repositories.tf
@@ -404,11 +404,12 @@ resource "github_repository_ruleset" "main" {
 
     # Pull request requirements
     pull_request {
-      dismiss_stale_reviews_on_push     = true # invalidate approvals when new commits are pushed
-      require_code_owner_review         = true # require approval from code owners
-      require_last_push_approval        = true # last pusher cannot self-approve
-      required_approving_review_count   = 2    # minimum number of approving reviews
-      required_review_thread_resolution = true # all conversations must be resolved
+      allowed_merge_methods             = ["squash", "rebase"] # only allow squash and rebase merges
+      dismiss_stale_reviews_on_push     = true                 # invalidate approvals when new commits are pushed
+      require_code_owner_review         = true                 # require approval from code owners
+      require_last_push_approval        = true                 # last pusher cannot self-approve
+      required_approving_review_count   = 2                    # minimum number of approving reviews
+      required_review_thread_resolution = true                 # all conversations must be resolved
     }
 
     # CI/CD status checks


### PR DESCRIPTION
## Summary

- Bump GitHub Actions to latest SHA-pinned versions across all workflows
  and repo default templates (codeql-action, cache, create-github-app-token,
  release-please-action, renovatebot/github-action, changed-files,
  pr-size-labeler, commit-check-action, upload-artifact, wrangler-action,
  prek-action)
- Update pre-commit hooks: rumdl v0.1.74, shfmt v3.13.1-1,
  commitizen v4.13.10
- Add `allowed_merge_methods` (squash, rebase) to GitHub repository
  ruleset pull_request block in OpenTofu config