### PR TITLE
chore: update workflow actions, pre-commit hooks, and opencode model

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
           - --args=--version "~> 1.11"
 
   - repo: https://github.com/rvben/rumdl-pre-commit
-    rev: v0.1.74
+    rev: v0.1.82
     hooks:
       - id: rumdl-fmt
 
@@ -136,7 +136,7 @@ repos:
         stages: [pre-push]
 
   - repo: https://github.com/commit-check/commit-check
-    rev: v2.5.0
+    rev: v2.6.0
     hooks:
       - id: check-message
       - id: check-branch

--- a/gh-repo-defaults/hugo/.github/workflows/gh-pages-build.yml
+++ b/gh-repo-defaults/hugo/.github/workflows/gh-pages-build.yml
@@ -13,12 +13,12 @@ on:
         default: false
   push:
     paths:
-      - content
-      - data
+      - content/**
+      - data/**
       - hugo.toml
-      - layouts
-      - static
-      - themes
+      - layouts/**
+      - static/**
+      - themes/**
 
 permissions: read-all
 

--- a/gh-repo-defaults/my-defaults/.github/workflows/pr-slack-notification.yml
+++ b/gh-repo-defaults/my-defaults/.github/workflows/pr-slack-notification.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - name: Post PR summary message to slack
         id: message
-        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
+        uses: slackapi/slack-github-action@03ea5433c137af7c0495bc0cad1af10403fc800c # v3.0.2
         with:
           method: chat.postMessage
           token: ${{ secrets.MY_SLACK_BOT_TOKEN }}
@@ -110,7 +110,7 @@ jobs:
 
       - name: React to PR summary message in slack with emoji
         if: ${{ steps.slack-timestamp.outputs.github_event_pull_request_html_url == 'true' && env.EMOJI != 'false' }}
-        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
+        uses: slackapi/slack-github-action@03ea5433c137af7c0495bc0cad1af10403fc800c # v3.0.2
         with:
           method: reactions.add
           token: ${{ secrets.MY_SLACK_BOT_TOKEN }}
@@ -121,7 +121,7 @@ jobs:
 
       - name: Update the original message with status Merged ✅
         if: ${{ github.event.pull_request.merged && steps.slack-timestamp.outputs.github_event_pull_request_html_url == 'true' }}
-        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
+        uses: slackapi/slack-github-action@03ea5433c137af7c0495bc0cad1af10403fc800c # v3.0.2
         with:
           method: chat.update
           token: ${{ secrets.MY_SLACK_BOT_TOKEN }}
@@ -138,7 +138,7 @@ jobs:
 
       - name: Update the original message with status Closed ❎
         if: ${{ github.event.action == 'closed' && github.event.pull_request.merged == false && steps.slack-timestamp.outputs.github_event_pull_request_html_url == 'true' }}
-        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
+        uses: slackapi/slack-github-action@03ea5433c137af7c0495bc0cad1af10403fc800c # v3.0.2
         with:
           method: chat.update
           token: ${{ secrets.MY_SLACK_BOT_TOKEN }}

--- a/gh-repo-defaults/my-defaults/.github/workflows/renovate.yml
+++ b/gh-repo-defaults/my-defaults/.github/workflows/renovate.yml
@@ -55,6 +55,6 @@ jobs:
           private-key: ${{ secrets.MY_RENOVATE_GITHUB_PRIVATE_KEY }}
 
       - name: 💡 Self-hosted Renovate
-        uses: renovatebot/github-action@eb932558ad942cccfd8211cf535f17ff183a9f74 # v46.1.9
+        uses: renovatebot/github-action@83ec54fee49ab67d9cd201084c1ff325b4b462e4 # v46.1.10
         with:
           token: ${{ steps.app-token.outputs.token }}

--- a/multi-gitter/multi-gitter-run-script.sh
+++ b/multi-gitter/multi-gitter-run-script.sh
@@ -153,7 +153,7 @@ esac
 if [[ ! -f "AGENTS.md" ]]; then
   log_info "Copying AGENTS.md from defaults and reinitializing with opencode"
   cp "${GH_REPO_DEFAULTS_BASE}/my-defaults/AGENTS.md" AGENTS.md
-  opencode run --model="github-copilot/claude-opus-4.6" --command "init"
+  opencode run --model="github-copilot/claude-opus-4.7" --command "init"
 fi
 
 log_info "Completed processing ${REPOSITORY}"


### PR DESCRIPTION
## Summary

- Bump `slackapi/slack-github-action` to v3.0.2 (root + my-defaults)
- Bump `renovatebot/github-action` to v46.1.10 (renovate + renovate-working-days + my-defaults)
- Bump pre-commit hooks: `rumdl-pre-commit` v0.1.82, `commit-check` v2.6.0
- Fix Hugo `gh-pages-build` workflow path filters to match files within directories (`content/**`, `data/**`, `layouts/**`, `static/**`, `themes/**`)
- Bump opencode model to `claude-opus-4.7` in `multi-gitter-run-script.sh`