### PR TITLE
fix: use client-id for actions/create-github-app-token

### DIFF
--- a/.github/workflows/mega-linter-repos.yml
+++ b/.github/workflows/mega-linter-repos.yml
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token
         with:
-          app-id: ${{ secrets.MY_RENOVATE_GITHUB_APP_ID }}
+          client-id: ${{ secrets.MY_RENOVATE_GITHUB_APP_ID }}
           private-key: ${{ secrets.MY_RENOVATE_GITHUB_PRIVATE_KEY }}
 
       - name: Get repository list
@@ -107,7 +107,7 @@ jobs:
       - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token
         with:
-          app-id: ${{ secrets.MY_RENOVATE_GITHUB_APP_ID }}
+          client-id: ${{ secrets.MY_RENOVATE_GITHUB_APP_ID }}
           private-key: ${{ secrets.MY_RENOVATE_GITHUB_PRIVATE_KEY }}
 
       - name: Checkout ${{ matrix.repo }}

--- a/.github/workflows/renovate-working-days.yml
+++ b/.github/workflows/renovate-working-days.yml
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token
         with:
-          app-id: ${{ secrets.MY_RENOVATE_GITHUB_APP_ID }}
+          client-id: ${{ secrets.MY_RENOVATE_GITHUB_APP_ID }}
           private-key: ${{ secrets.MY_RENOVATE_GITHUB_PRIVATE_KEY }}
 
       - name: 💡 Self-hosted Renovate

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token
         with:
-          app-id: ${{ secrets.MY_RENOVATE_GITHUB_APP_ID }}
+          client-id: ${{ secrets.MY_RENOVATE_GITHUB_APP_ID }}
           private-key: ${{ secrets.MY_RENOVATE_GITHUB_PRIVATE_KEY }}
 
       - name: 💡 Self-hosted Renovate

--- a/gh-repo-defaults/my-defaults/.github/workflows/commit-check.yml
+++ b/gh-repo-defaults/my-defaults/.github/workflows/commit-check.yml
@@ -25,3 +25,6 @@ jobs:
         env:
           CCHK_SUBJECT_CAPITALIZED: false
           CCHK_SUBJECT_MAX_LENGTH: 72
+          # Skip branch-name checks for automation bots. Ex. dependabot hardcodes the `dependabot/<ecosystem>/...` branch prefix and cannot satisfy Conventional Branch
+          CCHK_IGNORE_AUTHORS: "copilot[bot],dependabot[bot],github-actions[bot]"
+          CCHK_BRANCH_IGNORE_AUTHORS: "copilot[bot],dependabot[bot],github-actions[bot]"

--- a/gh-repo-defaults/my-defaults/.github/workflows/renovate.yml
+++ b/gh-repo-defaults/my-defaults/.github/workflows/renovate.yml
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token
         with:
-          app-id: ${{ secrets.MY_RENOVATE_GITHUB_APP_ID }}
+          client-id: ${{ secrets.MY_RENOVATE_GITHUB_APP_ID }}
           private-key: ${{ secrets.MY_RENOVATE_GITHUB_PRIVATE_KEY }}
 
       - name: 💡 Self-hosted Renovate


### PR DESCRIPTION
## Summary

- Switch `actions/create-github-app-token` input from deprecated `app-id` to `client-id` across renovate and mega-linter workflows
- Extend `commit-check.yml` defaults to ignore branch/author checks for automation bots (copilot, dependabot, github-actions) which use hardcoded branch prefixes incompatible with Conventional Branch