### PR TITLE
chore: pin terraform provider versions and group renovate updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -70,6 +70,11 @@
       automerge: false,
     },
     {
+      description: "Group all Terraform provider updates into a single PR",
+      groupName: "terraform providers",
+      matchDatasources: ["terraform-provider"],
+    },
+    {
       description: "Ignore frequent renovate updates",
       enabled: false,
       matchPackageNames: ["renovatebot/github-action"],

--- a/opentofu/aws/main.tf
+++ b/opentofu/aws/main.tf
@@ -4,11 +4,11 @@ terraform {
     # keep-sorted start block=yes
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6"
+      version = "6.35.1"
     }
     local = {
       source  = "hashicorp/local"
-      version = "~> 2"
+      version = "2.7.0"
     }
     # keep-sorted end
   }

--- a/opentofu/cloudflare-github/main.tf
+++ b/opentofu/cloudflare-github/main.tf
@@ -21,35 +21,35 @@ terraform {
     # keep-sorted start block=yes
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6"
+      version = "6.43.0"
     }
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = "~> 5"
+      version = "5.19.0"
     }
     github = {
       source  = "integrations/github"
-      version = "~> 6"
+      version = "6.12.1"
     }
     http = {
       source  = "hashicorp/http"
-      version = "~> 3"
+      version = "3.5.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = "~> 3"
+      version = "3.8.1"
     }
     restapi = {
       source  = "Mastercard/restapi"
-      version = "~> 3"
+      version = "3.0.0"
     }
     supabase = {
       source  = "supabase/supabase"
-      version = "~> 1"
+      version = "1.9.0"
     }
     uptimerobot = {
       source  = "uptimerobot/uptimerobot"
-      version = "~> 1"
+      version = "1.4.4"
     }
     # keep-sorted end
   }


### PR DESCRIPTION
## Summary
- Pin all OpenTofu provider version constraints to exact versions (from lock files) instead of loose `~>` constraints, preventing unexpected upgrades
- Add Renovate package rule to group all `terraform-provider` datasource updates into a single PR