### PR TITLE
chore: group mise and github actions renovate updates into single PRs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -75,6 +75,16 @@
       matchDatasources: ["terraform-provider"],
     },
     {
+      description: "Group all GitHub Actions updates into a single PR",
+      groupName: "github actions",
+      matchManagers: ["github-actions"],
+    },
+    {
+      description: "Group all mise updates into a single PR",
+      groupName: "mise",
+      matchManagers: ["mise"],
+    },
+    {
       description: "Ignore frequent renovate updates",
       enabled: false,
       matchPackageNames: ["renovatebot/github-action"],


### PR DESCRIPTION
## Summary

- Group all mise tool updates into a single Renovate PR
- Group all GitHub Actions updates into a single Renovate PR