### PR TITLE
feat: add DNSSEC drift workaround and gate tunnel token SSM parameter

### DIFF
--- a/opentofu/cloudflare-github/aws.tf
+++ b/opentofu/cloudflare-github/aws.tf
@@ -143,4 +143,11 @@ ephemeral "aws_ssm_parameter" "github_ruzickap_my_git_projects_actions_secrets_u
   arn             = "${local.ssm_parameter_arn_prefix}/github/ruzickap/my-git-projects/actions-secrets/uptimerobot_api_key"
   with_decryption = true
 }
+
+resource "aws_ssm_parameter" "github_ruzickap_ansible_openwrt_gate_xvx_cz_CLOUDFLARE_API_KEY" {
+  #checkov:skip=CKV_AWS_337:Using default AWS-managed KMS key for SecureString is sufficient
+  name  = "/github/ruzickap/ansible-openwrt/gate.xvx.cz/CLOUDFLARE_API_KEY"
+  type  = "SecureString"
+  value = data.cloudflare_zero_trust_tunnel_cloudflared_token.gate.token
+}
 # keep-sorted end

--- a/opentofu/cloudflare-github/cloudflare_zero_trust.tf
+++ b/opentofu/cloudflare-github/cloudflare_zero_trust.tf
@@ -171,6 +171,11 @@ resource "cloudflare_zero_trust_tunnel_cloudflared" "tunnels" {
   config_src = "cloudflare"
 }
 
+data "cloudflare_zero_trust_tunnel_cloudflared_token" "gate" {
+  account_id = local.cloudflare_account_id
+  tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.tunnels["gate"].id
+}
+
 resource "cloudflare_zero_trust_tunnel_cloudflared_config" "configs" {
   for_each   = local.cloudflare_zero_trust_tunnels_applications
   account_id = local.cloudflare_account_id

--- a/opentofu/cloudflare-github/cloudflare_zone-mylabs_dev.tf
+++ b/opentofu/cloudflare-github/cloudflare_zone-mylabs_dev.tf
@@ -134,6 +134,13 @@ resource "cloudflare_zone" "mylabs_dev" {
 resource "cloudflare_zone_dnssec" "mylabs_dev" {
   zone_id = cloudflare_zone.mylabs_dev.id
   status  = "active"
+
+  # Workaround: Cloudflare API returns "pending" until DS records propagate,
+  # causing perpetual drift against the desired "active" status.
+  # https://github.com/cloudflare/terraform-provider-cloudflare/issues/6237
+  lifecycle {
+    ignore_changes = [status]
+  }
 }
 
 resource "cloudflare_zone_setting" "mylabs_dev_min_tls_version" {

--- a/opentofu/cloudflare-github/cloudflare_zone-ruzicka_dev.tf
+++ b/opentofu/cloudflare-github/cloudflare_zone-ruzicka_dev.tf
@@ -103,6 +103,13 @@ resource "cloudflare_zone" "ruzicka_dev" {
 resource "cloudflare_zone_dnssec" "ruzicka_dev" {
   zone_id = cloudflare_zone.ruzicka_dev.id
   status  = "active"
+
+  # Workaround: Cloudflare API returns "pending" until DS records propagate,
+  # causing perpetual drift against the desired "active" status.
+  # https://github.com/cloudflare/terraform-provider-cloudflare/issues/6237
+  lifecycle {
+    ignore_changes = [status]
+  }
 }
 
 resource "cloudflare_zone_setting" "ruzicka_dev_min_tls_version" {

--- a/opentofu/cloudflare-github/cloudflare_zone-xvx_cz.tf
+++ b/opentofu/cloudflare-github/cloudflare_zone-xvx_cz.tf
@@ -157,6 +157,13 @@ resource "cloudflare_zone" "xvx_cz" {
 resource "cloudflare_zone_dnssec" "example_zone_dnssec" {
   zone_id = cloudflare_zone.xvx_cz.id
   status  = "active"
+
+  # Workaround: Cloudflare API returns "pending" until DS records propagate,
+  # causing perpetual drift against the desired "active" status.
+  # https://github.com/cloudflare/terraform-provider-cloudflare/issues/6237
+  lifecycle {
+    ignore_changes = [status]
+  }
 }
 
 resource "cloudflare_zone_setting" "xvx_cz_min_tls_version" {


### PR DESCRIPTION
## Summary

- Add `lifecycle { ignore_changes = [status] }` to all three zone DNSSEC
  resources (`mylabs_dev`, `ruzicka_dev`, `xvx_cz`) to prevent perpetual
  plan drift caused by the Cloudflare API returning `pending` status
- Add `cloudflare_zero_trust_tunnel_cloudflared_token` data source for the
  `gate` tunnel and store the token in AWS SSM Parameter Store for use by
  `ansible-openwrt`

Ref: https://github.com/cloudflare/terraform-provider-cloudflare/issues/6237