### PR TITLE
chore: update workflow secrets, security, and merge settings

### DIFF
--- a/.github/workflows/mega-linter-repos.yml
+++ b/.github/workflows/mega-linter-repos.yml
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          client-id: ${{ secrets.MY_RENOVATE_GITHUB_APP_ID }}
+          client-id: ${{ secrets.MY_RENOVATE_GITHUB_CLIENT_ID }}
           private-key: ${{ secrets.MY_RENOVATE_GITHUB_PRIVATE_KEY }}
           permission-contents: read
           permission-metadata: read
@@ -110,7 +110,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          client-id: ${{ secrets.MY_RENOVATE_GITHUB_APP_ID }}
+          client-id: ${{ secrets.MY_RENOVATE_GITHUB_CLIENT_ID }}
           private-key: ${{ secrets.MY_RENOVATE_GITHUB_PRIVATE_KEY }}
           permission-contents: read
 

--- a/.github/workflows/renovate-working-days.yml
+++ b/.github/workflows/renovate-working-days.yml
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          client-id: ${{ secrets.MY_RENOVATE_GITHUB_APP_ID }}
+          client-id: ${{ secrets.MY_RENOVATE_GITHUB_CLIENT_ID }}
           private-key: ${{ secrets.MY_RENOVATE_GITHUB_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -51,13 +51,15 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          client-id: ${{ secrets.MY_RENOVATE_GITHUB_APP_ID }}
+          client-id: ${{ secrets.MY_RENOVATE_GITHUB_CLIENT_ID }}
           private-key: ${{ secrets.MY_RENOVATE_GITHUB_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write
           permission-issues: write
           permission-checks: read
           permission-metadata: read
+          permission-statuses: write
+          permission-workflows: write
 
       - name: 💡 Self-hosted Renovate
         uses: renovatebot/github-action@693b9ef15eec82123529a37c782242f091365961 # v46.1.14

--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -6,8 +6,7 @@ name: semantic-pull-request
 
 on:
   workflow_dispatch:
-  # zizmor: ignore[dangerous-triggers] - only reads PR metadata, no code checkout
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited
@@ -24,4 +23,4 @@ jobs:
       - name: Validate semantic pull request title
         uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}

--- a/gh-repo-defaults/ansible/.gitignore
+++ b/gh-repo-defaults/ansible/.gitignore
@@ -8,6 +8,6 @@
 # Byte-compiled files
 __pycache__/
 
-# Ansible vault password file
-vault-*.password
+# Ansible temporary files
+ansible/.ansible/
 # keep-sorted end

--- a/gh-repo-defaults/ansible/.mega-linter.yml
+++ b/gh-repo-defaults/ansible/.mega-linter.yml
@@ -6,6 +6,10 @@
 # and in individual linters documentation
 
 # keep-sorted start newline_separated=yes
+# Allow zizmor (GitHub Actions security scanner) to access GitHub token
+ACTION_ZIZMOR_UNSECURED_ENV_VARIABLES:
+  - GITHUB_TOKEN
+
 ANSIBLE_ANSIBLE_LINT_CONFIG_FILE: ansible/.ansible-lint
 
 ANSIBLE_ANSIBLE_LINT_PRE_COMMANDS:
@@ -25,6 +29,7 @@ BASH_SHFMT_ARGUMENTS: --case-indent --indent 2 --space-redirects
 DISABLE_LINTERS:
   - MARKDOWN_MARKDOWNLINT # Using rumdl instead (faster Rust-based alternative)
   - MARKDOWN_MARKDOWN_LINK_CHECK # Using lychee instead for link checking (more configurable)
+  - REPOSITORY_OSV_SCANNER # No package sources in this repo - causes false failures
   - SPELL_CSPELL # Spell checking disabled - prone to false positives
   - TERRAFORM_TERRASCAN # Hard to configure - no clear documentation of the config file format
 

--- a/gh-repo-defaults/my-defaults/.github/workflows/renovate.yml
+++ b/gh-repo-defaults/my-defaults/.github/workflows/renovate.yml
@@ -51,13 +51,15 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          client-id: ${{ secrets.MY_RENOVATE_GITHUB_APP_ID }}
+          client-id: ${{ secrets.MY_RENOVATE_GITHUB_CLIENT_ID }}
           private-key: ${{ secrets.MY_RENOVATE_GITHUB_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write
           permission-issues: write
           permission-checks: read
           permission-metadata: read
+          permission-statuses: write
+          permission-workflows: write
 
       - name: 💡 Self-hosted Renovate
         uses: renovatebot/github-action@693b9ef15eec82123529a37c782242f091365961 # v46.1.14

--- a/gh-repo-defaults/my-defaults/.github/workflows/semantic-pull-request.yml
+++ b/gh-repo-defaults/my-defaults/.github/workflows/semantic-pull-request.yml
@@ -6,8 +6,7 @@ name: semantic-pull-request
 
 on:
   workflow_dispatch:
-  # zizmor: ignore[dangerous-triggers] - only reads PR metadata, no code checkout
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited
@@ -24,4 +23,4 @@ jobs:
       - name: Validate semantic pull request title
         uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}

--- a/opentofu/cloudflare-github/aws.tf
+++ b/opentofu/cloudflare-github/aws.tf
@@ -99,6 +99,11 @@ data "aws_ssm_parameter" "github_shared_actions_secrets_MY_RENOVATE_GITHUB_APP_I
   with_decryption = true
 }
 
+data "aws_ssm_parameter" "github_shared_actions_secrets_MY_RENOVATE_GITHUB_CLIENT_ID" {
+  name            = "/github/shared/actions-secrets/MY_RENOVATE_GITHUB_CLIENT_ID"
+  with_decryption = true
+}
+
 data "aws_ssm_parameter" "github_shared_actions_secrets_MY_RENOVATE_GITHUB_PRIVATE_KEY" {
   name            = "/github/shared/actions-secrets/MY_RENOVATE_GITHUB_PRIVATE_KEY"
   with_decryption = true

--- a/opentofu/cloudflare-github/github-repositories.tf
+++ b/opentofu/cloudflare-github/github-repositories.tf
@@ -251,7 +251,7 @@ resource "github_repository" "this" {
   #checkov:skip=CKV2_GIT_1:Ensure each Repository has branch protection associated
   for_each = local.all_github_repositories
   # Merge settings
-  allow_auto_merge       = true  # enable auto-merge for PRs
+  allow_auto_merge       = false # disable auto-merge for PRs
   allow_merge_commit     = false # disable merge commits, use squash only
   allow_rebase_merge     = false # disable rebase merging
   allow_update_branch    = true  # allow updating PR branches from base branch

--- a/opentofu/cloudflare-github/github-repositories.tf
+++ b/opentofu/cloudflare-github/github-repositories.tf
@@ -4,7 +4,8 @@ locals {
   # Default secrets applied to all GitHub repositories
   github_action_default_secrets = {
     # keep-sorted start
-    "MY_RENOVATE_GITHUB_APP_ID"      = data.aws_ssm_parameter.github_shared_actions_secrets_MY_RENOVATE_GITHUB_APP_ID.value
+    "MY_RENOVATE_GITHUB_APP_ID"      = data.aws_ssm_parameter.github_shared_actions_secrets_MY_RENOVATE_GITHUB_APP_ID.value # TODO: delete in July, replaced by MY_RENOVATE_GITHUB_CLIENT_ID
+    "MY_RENOVATE_GITHUB_CLIENT_ID"   = data.aws_ssm_parameter.github_shared_actions_secrets_MY_RENOVATE_GITHUB_CLIENT_ID.value
     "MY_RENOVATE_GITHUB_PRIVATE_KEY" = data.aws_ssm_parameter.github_shared_actions_secrets_MY_RENOVATE_GITHUB_PRIVATE_KEY.value
     "MY_SLACK_BOT_TOKEN"             = data.aws_ssm_parameter.github_shared_actions_secrets_MY_SLACK_BOT_TOKEN.value
     "MY_SLACK_CHANNEL_ID"            = data.aws_ssm_parameter.github_shared_actions_secrets_MY_SLACK_CHANNEL_ID.value
@@ -250,7 +251,9 @@ resource "github_repository" "this" {
   #checkov:skip=CKV2_GIT_1:Ensure each Repository has branch protection associated
   for_each = local.all_github_repositories
   # Merge settings
-  allow_merge_commit     = false # disable merge commits, use squash/rebase only
+  allow_auto_merge       = true  # enable auto-merge for PRs
+  allow_merge_commit     = false # disable merge commits, use squash only
+  allow_rebase_merge     = false # disable rebase merging
   allow_update_branch    = true  # allow updating PR branches from base branch
   delete_branch_on_merge = true  # auto-delete head branches after merge
 
@@ -388,12 +391,12 @@ resource "github_repository_ruleset" "main" {
 
     # Pull request requirements
     pull_request {
-      allowed_merge_methods             = ["squash", "rebase"] # only allow squash and rebase merges
-      dismiss_stale_reviews_on_push     = true                 # invalidate approvals when new commits are pushed
-      require_code_owner_review         = true                 # require approval from code owners
-      require_last_push_approval        = true                 # last pusher cannot self-approve
-      required_approving_review_count   = 2                    # minimum number of approving reviews
-      required_review_thread_resolution = true                 # all conversations must be resolved
+      allowed_merge_methods             = ["squash"] # only allow squash merges
+      dismiss_stale_reviews_on_push     = true       # invalidate approvals when new commits are pushed
+      require_code_owner_review         = true       # require approval from code owners
+      require_last_push_approval        = true       # last pusher cannot self-approve
+      required_approving_review_count   = 2          # minimum number of approving reviews
+      required_review_thread_resolution = true       # all conversations must be resolved
     }
 
     # Copilot code review


### PR DESCRIPTION
## Summary

- Rename `MY_RENOVATE_GITHUB_APP_ID` to `MY_RENOVATE_GITHUB_CLIENT_ID` across workflows and add the new secret to OpenTofu config
- Add `permission-statuses` and `permission-workflows` to Renovate GitHub App token
- Switch `semantic-pull-request` workflow from `pull_request_target` to `pull_request` and use `github.token`
- Enable auto-merge, disable rebase merge, restrict to squash-only merges in repo settings and rulesets
- Update ansible repo defaults (gitignore, mega-linter config)