### PR TITLE
chore: add lifecycle create_before_destroy to aws_credentials

### DIFF
--- a/opentofu/aws/main.tf
+++ b/opentofu/aws/main.tf
@@ -100,6 +100,10 @@ resource "local_sensitive_file" "aws_credentials" {
     aws_access_key_id = ${aws_iam_access_key.this.id}
     aws_secret_access_key = ${aws_iam_access_key.this.secret}
   EOT
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "local_sensitive_file" "aws_config" {


### PR DESCRIPTION
Add `create_before_destroy = true` lifecycle block to the `local_sensitive_file.aws_credentials` resource to ensure the new credentials file is written before the old one is removed during replacements.