### PR TITLE
feat: add global renovate workflow for all repositories

### DIFF
--- a/.github/workflows/renovate-global.yml
+++ b/.github/workflows/renovate-global.yml
@@ -1,0 +1,69 @@
+---
+# GitHub Actions workflow for global Renovate dependency management
+# Renovate automatically updates dependencies across all non-archived repositories
+name: renovate-global
+
+on:
+  workflow_dispatch:
+    inputs:
+      dryRun:
+        type: boolean
+        description: Dry-Run
+      logLevel:
+        type: choice
+        description: Log-Level
+        default: debug
+        options:
+          - info
+          - debug
+          - trace
+  # schedule:
+  #   - cron: 0 4-6 * * 0
+
+env:
+  # keep-sorted start
+  # Set log level for debugging (info, debug, or trace) https://docs.renovatebot.com/troubleshooting/#log-debug-levels
+  LOG_LEVEL: ${{ inputs.logLevel || 'debug' }}
+  # Automatically discover all repositories accessible by the token
+  # https://docs.renovatebot.com/self-hosted-configuration/#autodiscover
+  RENOVATE_AUTODISCOVER: "true"
+  # Filter out archived repositories from autodiscovery
+  # https://docs.renovatebot.com/self-hosted-configuration/#autodiscoverfilter
+  RENOVATE_AUTODISCOVER_FILTER: "/^${{ github.repository_owner }}\\/.*/"
+  # Enable dry-run mode for non-main branches to preview changes (https://docs.renovatebot.com/self-hosted-configuration/#dryrun)
+  # Run renovate in dry-run mode if executed in branches other than main to prevent updating versions in PRs/branches
+  RENOVATE_DRY_RUN: ${{ inputs.dryRun || ( github.head_ref || github.ref_name ) != 'main' || false }}
+  # Skip archived repositories
+  # https://docs.renovatebot.com/self-hosted-configuration/#ignorearchived
+  RENOVATE_IGNORE_ARCHIVED: "true"
+  # Username for Renovate commits
+  # https://docs.renovatebot.com/self-hosted-configuration/#username
+  RENOVATE_USERNAME: ${{ github.repository_owner }}
+  # keep-sorted end
+
+permissions: read-all
+
+jobs:
+  renovate-global:
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 120
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+    steps:
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          client-id: ${{ secrets.MY_RENOVATE_GITHUB_CLIENT_ID }}
+          private-key: ${{ secrets.MY_RENOVATE_GITHUB_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+          permission-issues: write
+          permission-checks: read
+          permission-metadata: read
+          permission-statuses: write
+          permission-workflows: write
+
+      - name: 💡 Self-hosted Renovate
+        uses: renovatebot/github-action@693b9ef15eec82123529a37c782242f091365961 # v46.1.14
+        with:
+          token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
Add `renovate-global.yml` workflow that uses Renovate's autodiscover feature to update dependencies across all non-archived repositories owned by the repository owner.

## Changes

- New workflow: `.github/workflows/renovate-global.yml`
- Uses `RENOVATE_AUTODISCOVER` to find all accessible repositories
- Filters to owner's repositories via `RENOVATE_AUTODISCOVER_FILTER`
- Skips archived repositories with `RENOVATE_IGNORE_ARCHIVED`
- Schedule is commented out for initial testing via `workflow_dispatch`
- Timeout set to 120 minutes to handle many repositories