### PR TITLE
fix: scope renovate-global token to all owner repos

### DIFF
--- a/.github/renovate-global.json5
+++ b/.github/renovate-global.json5
@@ -39,7 +39,12 @@
       extractVersionTemplate: "{{#if extractVersion}}{{{extractVersion}}}{{else}}^v?(?<version>.+)${{/if}}",
 
       // File types to scan for custom dependency patterns
-      fileMatch: ["\\.ya?ml$", "\\.md$", "^Dockerfile$", "^entrypoint\\.sh$"],
+      managerFilePatterns: [
+        "/\\.ya?ml$/",
+        "/\\.md$/",
+        "/^Dockerfile$/",
+        "/^entrypoint\\.sh$/",
+      ],
 
       // Regex pattern to match custom dependency declarations
       // Format: # renovate: datasource=<source> depName=<name> [versioning=<type>] [extractVersion=<regex>] [registryUrl=<url>]
@@ -55,7 +60,7 @@
     {
       datasourceTemplate: "custom.grafana-dashboards",
       customType: "regex",
-      fileMatch: ["\\.md$"],
+      managerFilePatterns: ["/\\.md$/"],
       matchStrings: [
         '# renovate: depName="(?<depName>.*)"\\n\\s+gnetId:\\s+(?<packageName>.*?)\\n\\s+revision:\\s+(?<currentValue>.*)',
       ],
@@ -67,7 +72,7 @@
       customType: "regex",
       datasourceTemplate: "git-refs",
       packageNameTemplate: "https://github.com/{{depName}}",
-      fileMatch: ["\\.md$"],
+      managerFilePatterns: ["/\\.md$/"],
       matchStrings: [
         "# renovate:( currentValue=(?<currentValue>.+?))?\\n.*https:\\/\\/raw.githubusercontent.com\\/(?<depName>[^\\/]+\\/[^\\/]+)\\/(?<currentDigest>[^\\/]+)\\/",
       ],
@@ -87,7 +92,7 @@
   ],
   // Scan Kubernetes manifests in deploy directory (for malware-cryptominer-container)
   kubernetes: {
-    fileMatch: ["^deploy/.+\\.ya?ml$"],
+    managerFilePatterns: ["/^deploy/.+\\.ya?ml$/"],
   },
   // Pull Request Labeling
   labels: [

--- a/.github/renovate-global.json5
+++ b/.github/renovate-global.json5
@@ -14,12 +14,6 @@
   "git-submodules": {
     enabled: true,
   },
-  // Automatically discover all repositories accessible by the token
-  // https://docs.renovatebot.com/self-hosted-configuration/#autodiscover
-  autodiscover: true,
-  // Filter autodiscovery to only ruzickap repositories
-  // https://docs.renovatebot.com/self-hosted-configuration/#autodiscoverfilter
-  autodiscoverFilter: ["/^ruzickap\\/.*/"],
   // Automatically merge PRs when all tests pass
   // https://docs.renovatebot.com/configuration-options/#automerge
   automerge: true,
@@ -29,6 +23,14 @@
   // Custom prefix for Renovate branches
   // https://docs.renovatebot.com/configuration-options/#branchprefix
   branchPrefix: "chore/renovate/",
+  // Custom datasource for Grafana dashboard revisions (for ruzickap.github.io)
+  customDatasources: {
+    "grafana-dashboards": {
+      defaultRegistryUrlTemplate: "https://grafana.com/api/dashboards/{{packageName}}",
+      format: "json",
+      transformTemplates: ['{"releases":[{"version": $string(revision)}]}'],
+    },
+  },
   // This allows Renovate to detect and update dependencies that aren't in standard package files
   customManagers: [
     {
@@ -49,6 +51,27 @@
       // Default to semantic versioning unless specified otherwise
       versioningTemplate: "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
     },
+    // Custom manager for Grafana dashboard revisions (for ruzickap.github.io)
+    {
+      datasourceTemplate: "custom.grafana-dashboards",
+      customType: "regex",
+      fileMatch: ["\\.md$"],
+      matchStrings: [
+        '# renovate: depName="(?<depName>.*)"\\n\\s+gnetId:\\s+(?<packageName>.*?)\\n\\s+revision:\\s+(?<currentValue>.*)',
+      ],
+      versioningTemplate: "regex:^(?<major>\\d+)$",
+    },
+    // Custom manager for raw.githubusercontent.com URLs (for ruzickap.github.io)
+    {
+      currentValueTemplate: "{{#if currentValue}}{{{currentValue}}}{{else}}main{{/if}}",
+      customType: "regex",
+      datasourceTemplate: "git-refs",
+      packageNameTemplate: "https://github.com/{{depName}}",
+      fileMatch: ["\\.md$"],
+      matchStrings: [
+        "# renovate:( currentValue=(?<currentValue>.+?))?\\n.*https:\\/\\/raw.githubusercontent.com\\/(?<depName>[^\\/]+\\/[^\\/]+)\\/(?<currentDigest>[^\\/]+)\\/",
+      ],
+    },
   ],
   // Base Configuration Presets
   // Keep the extends started with ":" at the end of the list to allow overriding
@@ -62,9 +85,10 @@
     ":enableVulnerabilityAlertsWithLabel(security)", // Add security label to vulnerability alerts
     ":pinSkipCi", // Pin dependencies and skip CI for pin-only updates
   ],
-  // Skip archived repositories
-  // https://docs.renovatebot.com/self-hosted-configuration/#ignorearchived
-  ignoreArchived: true,
+  // Scan Kubernetes manifests in deploy directory (for malware-cryptominer-container)
+  kubernetes: {
+    fileMatch: ["^deploy/.+\\.ya?ml$"],
+  },
   // Pull Request Labeling
   labels: [
     "renovate",
@@ -107,6 +131,43 @@
       groupName: "mise",
       matchManagers: ["mise"],
     },
+    {
+      description: "Only update GitHub Actions in brewwatch repo",
+      matchRepositories: ["ruzickap/brewwatch"],
+      matchManagers: ["!github-actions"],
+      enabled: false,
+    },
+    {
+      description: "Auto-merge digest updates for malware-cryptominer-container",
+      matchRepositories: ["ruzickap/malware-cryptominer-container"],
+      matchUpdateTypes: ["digest"],
+      automerge: true,
+      minimumReleaseAge: "3 days",
+    },
+    {
+      description: "Skip pinning for slsa-framework/slsa-github-generator",
+      matchRepositories: ["ruzickap/malware-cryptominer-container"],
+      matchPackageNames: ["slsa-framework/slsa-github-generator"],
+      pinDigests: false,
+    },
+    {
+      description: "Grafana Dashboards automerge for ruzickap.github.io",
+      matchRepositories: ["ruzickap/ruzickap.github.io"],
+      matchDatasources: ["custom.grafana-dashboards"],
+      matchUpdateTypes: ["major"],
+      automerge: true,
+      commitBody: "[skip ci]",
+      ignoreTests: true,
+    },
+    {
+      description: "Automerge all patch, pin and digest updates for custom.regex in ruzickap.github.io",
+      matchRepositories: ["ruzickap/ruzickap.github.io"],
+      matchManagers: ["custom.regex"],
+      matchUpdateTypes: ["patch", "pin", "digest"],
+      automerge: true,
+      commitBody: "[skip ci]",
+      ignoreTests: true,
+    },
   ],
   // PR body template showing dependency table, notes, and changelogs
   // https://docs.renovatebot.com/configuration-options/#prbodytemplate
@@ -114,92 +175,8 @@
   // Rebase branches when they fall behind the base branch
   // https://docs.renovatebot.com/configuration-options/#rebasewhen
   rebaseWhen: "behind-base-branch",
-  // Repository-specific rules for the global Renovate workflow
-  // https://docs.renovatebot.com/configuration-options/#repositoryrules
-  repositoryRules: [
-    {
-      description: "Only update GitHub Actions in brewwatch repo",
-      matchRepositories: ["ruzickap/brewwatch"],
-      enabledManagers: ["github-actions"],
-    },
-    {
-      description: "Repo-specific config for malware-cryptominer-container",
-      matchRepositories: ["ruzickap/malware-cryptominer-container"],
-      kubernetes: {
-        fileMatch: ["^deploy/.+\\.ya?ml$"],
-      },
-      packageRules: [
-        {
-          description: "Auto-merge digest updates after a 3 day age gate",
-          matchUpdateTypes: ["digest"],
-          automerge: true,
-          minimumReleaseAge: "3 days",
-        },
-        {
-          description: "Skip pinning for slsa-framework/slsa-github-generator",
-          matchPackageNames: ["slsa-framework/slsa-github-generator"],
-          pinDigests: false,
-        },
-      ],
-    },
-    {
-      description: "Repo-specific config for ruzickap.github.io",
-      matchRepositories: ["ruzickap/ruzickap.github.io"],
-      customDatasources: {
-        "grafana-dashboards": {
-          defaultRegistryUrlTemplate: "https://grafana.com/api/dashboards/{{packageName}}",
-          format: "json",
-          transformTemplates: ['{"releases":[{"version": $string(revision)}]}'],
-        },
-      },
-      customManagers: [
-        {
-          datasourceTemplate: "custom.grafana-dashboards",
-          customType: "regex",
-          fileMatch: ["\\.md$"],
-          matchStrings: [
-            '# renovate: depName="(?<depName>.*)"\\n\\s+gnetId:\\s+(?<packageName>.*?)\\n\\s+revision:\\s+(?<currentValue>.*)',
-          ],
-          versioningTemplate: "regex:^(?<major>\\d+)$",
-        },
-        {
-          currentValueTemplate: "{{#if currentValue}}{{{currentValue}}}{{else}}main{{/if}}",
-          customType: "regex",
-          datasourceTemplate: "git-refs",
-          packageNameTemplate: "https://github.com/{{depName}}",
-          fileMatch: ["\\.md$"],
-          matchStrings: [
-            "# renovate:( currentValue=(?<currentValue>.+?))?\\n.*https:\\/\\/raw.githubusercontent.com\\/(?<depName>[^\\/]+\\/[^\\/]+)\\/(?<currentDigest>[^\\/]+)\\/",
-          ],
-        },
-      ],
-      // Ignore chirpy blog post dependencies
-      ignorePaths: ["_posts/**"],
-      packageRules: [
-        {
-          automerge: true,
-          commitBody: "[skip ci]",
-          description: "Grafana Dashboards",
-          ignoreTests: true,
-          matchDatasources: ["custom.grafana-dashboards"],
-          matchUpdateTypes: ["major"],
-        },
-        {
-          automerge: true,
-          commitBody: "[skip ci]",
-          description: "Automerge all patch, pin and digest updates for custom.regex without running any tests",
-          ignoreTests: true,
-          matchManagers: ["custom.regex"],
-          matchUpdateTypes: ["patch", "pin", "digest"],
-        },
-      ],
-    },
-  ],
   // Create separate branches for minor and patch updates
   // https://docs.renovatebot.com/configuration-options/#separateminorpatch
   separateMinorPatch: true,
-  // Username for Renovate commits
-  // https://docs.renovatebot.com/self-hosted-configuration/#username
-  username: "ruzickap",
   // # keep-sorted end
 }

--- a/.github/renovate-global.json5
+++ b/.github/renovate-global.json5
@@ -108,7 +108,11 @@
       matchManagers: ["mise"],
     },
   ],
+  // PR body template showing dependency table, notes, and changelogs
+  // https://docs.renovatebot.com/configuration-options/#prbodytemplate
   prBodyTemplate: "{{{table}}}{{{notes}}}{{{changelogs}}}",
+  // Rebase branches when they fall behind the base branch
+  // https://docs.renovatebot.com/configuration-options/#rebasewhen
   rebaseWhen: "behind-base-branch",
   // Repository-specific rules for the global Renovate workflow
   // https://docs.renovatebot.com/configuration-options/#repositoryrules
@@ -191,6 +195,8 @@
       ],
     },
   ],
+  // Create separate branches for minor and patch updates
+  // https://docs.renovatebot.com/configuration-options/#separateminorpatch
   separateMinorPatch: true,
   // Username for Renovate commits
   // https://docs.renovatebot.com/self-hosted-configuration/#username

--- a/.github/renovate-global.json5
+++ b/.github/renovate-global.json5
@@ -20,8 +20,14 @@
   // Filter autodiscovery to only ruzickap repositories
   // https://docs.renovatebot.com/self-hosted-configuration/#autodiscoverfilter
   autodiscoverFilter: ["/^ruzickap\\/.*/"],
+  // Automatically merge PRs when all tests pass
+  // https://docs.renovatebot.com/configuration-options/#automerge
   automerge: true,
+  // Merge directly to the base branch without creating a PR
+  // https://docs.renovatebot.com/configuration-options/#automergetype
   automergeType: "branch",
+  // Custom prefix for Renovate branches
+  // https://docs.renovatebot.com/configuration-options/#branchprefix
   branchPrefix: "chore/renovate/",
   // This allows Renovate to detect and update dependencies that aren't in standard package files
   customManagers: [

--- a/.github/renovate-global.json5
+++ b/.github/renovate-global.json5
@@ -1,0 +1,193 @@
+{
+  /**
+   * Renovate Global Configuration
+   *
+   * This configuration is used by the renovate-global workflow to manage
+   * dependency updates across all repositories. It extends the base config
+   * and adds repository-specific rules.
+   *
+   * Documentation: https://docs.renovatebot.com/configuration-options/
+   */
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+
+  // # keep-sorted start block=yes
+  "git-submodules": {
+    enabled: true,
+  },
+  // Automatically discover all repositories accessible by the token
+  // https://docs.renovatebot.com/self-hosted-configuration/#autodiscover
+  autodiscover: true,
+  // Filter autodiscovery to only ruzickap repositories
+  // https://docs.renovatebot.com/self-hosted-configuration/#autodiscoverfilter
+  autodiscoverFilter: ["/^ruzickap\\/.*/"],
+  automerge: true,
+  automergeType: "branch",
+  branchPrefix: "chore/renovate/",
+  // This allows Renovate to detect and update dependencies that aren't in standard package files
+  customManagers: [
+    {
+      customType: "regex",
+      // Template for extracting version numbers from custom patterns
+      extractVersionTemplate: "{{#if extractVersion}}{{{extractVersion}}}{{else}}^v?(?<version>.+)${{/if}}",
+
+      // File types to scan for custom dependency patterns
+      fileMatch: ["\\.ya?ml$", "\\.md$", "^Dockerfile$", "^entrypoint\\.sh$"],
+
+      // Regex pattern to match custom dependency declarations
+      // Format: # renovate: datasource=<source> depName=<name> [versioning=<type>] [extractVersion=<regex>] [registryUrl=<url>]
+      // Example: # renovate: datasource=github-releases depName=helm/helm versioning=semver
+      matchStrings: [
+        '# renovate: datasource=(?<datasource>.+?) depName=(?<depName>.+?)( versioning=(?<versioning>.+?))?( extractVersion=(?<extractVersion>.+?))?( registryUrl=(?<registryUrl>.+?))?\\s.*[=:]\\s*"?(?<currentValue>.+?)"?\\s',
+      ],
+
+      // Default to semantic versioning unless specified otherwise
+      versioningTemplate: "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
+    },
+  ],
+  // Base Configuration Presets
+  // Keep the extends started with ":" at the end of the list to allow overriding
+  extends: [
+    "config:recommended", // Renovate's recommended configuration preset
+    "docker:pinDigests", // Pin Docker image digests for security
+    "helpers:pinGitHubActionDigestsToSemver", // Pin GitHub Actions to specific versions with semantic versioning
+    "security:openssf-scorecard", // Add OpenSSF Scorecard security insights
+    ":disableDependencyDashboard", // Don't create dependency dashboard issues
+    ":disableRateLimiting", // Disable rate limiting for faster updates
+    ":enableVulnerabilityAlertsWithLabel(security)", // Add security label to vulnerability alerts
+    ":pinSkipCi", // Pin dependencies and skip CI for pin-only updates
+  ],
+  // Skip archived repositories
+  // https://docs.renovatebot.com/self-hosted-configuration/#ignorearchived
+  ignoreArchived: true,
+  // Pull Request Labeling
+  labels: [
+    "renovate",
+    "renovate/{{replace '.*/' '' depName}}",
+    "renovate/{{updateType}}",
+  ],
+  // Lock File Maintenance
+  lockFileMaintenance: {
+    enabled: true,
+    schedule: ["before 6am on Sunday"],
+  },
+  // Wait for releases to be at least 3 days old before creating PRs (reduces risk of buggy releases)
+  minimumReleaseAge: "3 days",
+  // Package-specific Update Rules
+  packageRules: [
+    {
+      description: "Disable auto-merge for major updates",
+      matchUpdateTypes: ["major"],
+      automerge: false,
+    },
+    {
+      description: "Ignore frequent renovate updates",
+      enabled: false,
+      matchPackageNames: ["renovatebot/github-action"],
+      matchUpdateTypes: ["patch"],
+    },
+    {
+      description: "Update renovatebot/github-action minor updates on Sundays",
+      matchPackageNames: ["renovatebot/github-action"],
+      matchUpdateTypes: ["minor"],
+      schedule: ["* * * * 0"],
+    },
+    {
+      description: "Group all GitHub Actions updates into a single PR",
+      groupName: "github actions",
+      matchManagers: ["github-actions"],
+    },
+    {
+      description: "Group all mise updates into a single PR",
+      groupName: "mise",
+      matchManagers: ["mise"],
+    },
+  ],
+  prBodyTemplate: "{{{table}}}{{{notes}}}{{{changelogs}}}",
+  rebaseWhen: "behind-base-branch",
+  // Repository-specific rules for the global Renovate workflow
+  // https://docs.renovatebot.com/configuration-options/#repositoryrules
+  repositoryRules: [
+    {
+      description: "Only update GitHub Actions in brewwatch repo",
+      matchRepositories: ["ruzickap/brewwatch"],
+      enabledManagers: ["github-actions"],
+    },
+    {
+      description: "Repo-specific config for malware-cryptominer-container",
+      matchRepositories: ["ruzickap/malware-cryptominer-container"],
+      kubernetes: {
+        fileMatch: ["^deploy/.+\\.ya?ml$"],
+      },
+      packageRules: [
+        {
+          description: "Auto-merge digest updates after a 3 day age gate",
+          matchUpdateTypes: ["digest"],
+          automerge: true,
+          minimumReleaseAge: "3 days",
+        },
+        {
+          description: "Skip pinning for slsa-framework/slsa-github-generator",
+          matchPackageNames: ["slsa-framework/slsa-github-generator"],
+          pinDigests: false,
+        },
+      ],
+    },
+    {
+      description: "Repo-specific config for ruzickap.github.io",
+      matchRepositories: ["ruzickap/ruzickap.github.io"],
+      customDatasources: {
+        "grafana-dashboards": {
+          defaultRegistryUrlTemplate: "https://grafana.com/api/dashboards/{{packageName}}",
+          format: "json",
+          transformTemplates: ['{"releases":[{"version": $string(revision)}]}'],
+        },
+      },
+      customManagers: [
+        {
+          datasourceTemplate: "custom.grafana-dashboards",
+          customType: "regex",
+          fileMatch: ["\\.md$"],
+          matchStrings: [
+            '# renovate: depName="(?<depName>.*)"\\n\\s+gnetId:\\s+(?<packageName>.*?)\\n\\s+revision:\\s+(?<currentValue>.*)',
+          ],
+          versioningTemplate: "regex:^(?<major>\\d+)$",
+        },
+        {
+          currentValueTemplate: "{{#if currentValue}}{{{currentValue}}}{{else}}main{{/if}}",
+          customType: "regex",
+          datasourceTemplate: "git-refs",
+          packageNameTemplate: "https://github.com/{{depName}}",
+          fileMatch: ["\\.md$"],
+          matchStrings: [
+            "# renovate:( currentValue=(?<currentValue>.+?))?\\n.*https:\\/\\/raw.githubusercontent.com\\/(?<depName>[^\\/]+\\/[^\\/]+)\\/(?<currentDigest>[^\\/]+)\\/",
+          ],
+        },
+      ],
+      // Ignore chirpy blog post dependencies
+      ignorePaths: ["_posts/**"],
+      packageRules: [
+        {
+          automerge: true,
+          commitBody: "[skip ci]",
+          description: "Grafana Dashboards",
+          ignoreTests: true,
+          matchDatasources: ["custom.grafana-dashboards"],
+          matchUpdateTypes: ["major"],
+        },
+        {
+          automerge: true,
+          commitBody: "[skip ci]",
+          description: "Automerge all patch, pin and digest updates for custom.regex without running any tests",
+          ignoreTests: true,
+          matchManagers: ["custom.regex"],
+          matchUpdateTypes: ["patch", "pin", "digest"],
+        },
+      ],
+    },
+  ],
+  separateMinorPatch: true,
+  // Username for Renovate commits
+  // https://docs.renovatebot.com/self-hosted-configuration/#username
+  username: "ruzickap",
+  // # keep-sorted end
+}

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,8 +13,14 @@
   "git-submodules": {
     enabled: true,
   },
+  // Automatically merge PRs when all tests pass
+  // https://docs.renovatebot.com/configuration-options/#automerge
   automerge: true,
+  // Merge directly to the base branch without creating a PR
+  // https://docs.renovatebot.com/configuration-options/#automergetype
   automergeType: "branch",
+  // Custom prefix for Renovate branches
+  // https://docs.renovatebot.com/configuration-options/#branchprefix
   branchPrefix: "chore/renovate/",
   // This allows Renovate to detect and update dependencies that aren't in standard package files
   customManagers: [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,14 +13,8 @@
   "git-submodules": {
     enabled: true,
   },
-  // Automatically merge PRs when all tests pass
-  // https://docs.renovatebot.com/configuration-options/#automerge
   automerge: true,
-  // Merge directly to the base branch without creating a PR
-  // https://docs.renovatebot.com/configuration-options/#automergetype
   automergeType: "branch",
-  // Custom prefix for Renovate branches
-  // https://docs.renovatebot.com/configuration-options/#branchprefix
   branchPrefix: "chore/renovate/",
   // This allows Renovate to detect and update dependencies that aren't in standard package files
   customManagers: [

--- a/.github/workflows/renovate-global.yml
+++ b/.github/workflows/renovate-global.yml
@@ -16,9 +16,21 @@ env:
   # keep-sorted start
   # Set log level for debugging (info, debug, or trace) https://docs.renovatebot.com/troubleshooting/#log-debug-levels
   LOG_LEVEL: info
+  # Automatically discover all repositories accessible by the token
+  # https://docs.renovatebot.com/self-hosted-configuration/#autodiscover
+  RENOVATE_AUTODISCOVER: "true"
+  # Filter autodiscovery to only ruzickap repositories
+  # https://docs.renovatebot.com/self-hosted-configuration/#autodiscoverfilter
+  RENOVATE_AUTODISCOVER_FILTER: "/^${{ github.repository_owner }}\\/.*/"
   # Enable dry-run mode for non-main branches to preview changes (https://docs.renovatebot.com/self-hosted-configuration/#dryrun)
   # Run renovate in dry-run mode if executed in branches other than main to prevent updating versions in PRs/branches
   RENOVATE_DRY_RUN: ${{ inputs.dryRun || ( github.head_ref || github.ref_name ) != 'main' || false }}
+  # Skip archived repositories
+  # https://docs.renovatebot.com/self-hosted-configuration/#ignorearchived
+  RENOVATE_IGNORE_ARCHIVED: "true"
+  # Username for Renovate commits
+  # https://docs.renovatebot.com/self-hosted-configuration/#username
+  RENOVATE_USERNAME: ${{ github.repository_owner }}
   # keep-sorted end
 
 permissions: read-all

--- a/.github/workflows/renovate-global.yml
+++ b/.github/workflows/renovate-global.yml
@@ -74,8 +74,7 @@ jobs:
           GH_TOKEN: ${{ secrets.MY_COPILOT_TOKEN }}
         run: |
           # Fetch the Renovate step log from the current workflow run
-          gh run view "${{ github.run_id }}" --repo "${{ github.repository }}" --log 2>&1 \
-            | grep -E "(DRY-RUN|WARN|INFO.*Would|Autodiscovered|error in)" > /tmp/renovate-log.txt || true
+          gh run view "${{ github.run_id }}" --repo "${{ github.repository }}" --log > /tmp/renovate-log.txt 2>&1 || true
 
           copilot -p "Read the file /tmp/renovate-log.txt which contains Renovate bot output logs.
           Create a markdown summary organized by repository showing:

--- a/.github/workflows/renovate-global.yml
+++ b/.github/workflows/renovate-global.yml
@@ -24,21 +24,9 @@ env:
   # keep-sorted start
   # Set log level for debugging (info, debug, or trace) https://docs.renovatebot.com/troubleshooting/#log-debug-levels
   LOG_LEVEL: ${{ inputs.logLevel || 'debug' }}
-  # Automatically discover all repositories accessible by the token
-  # https://docs.renovatebot.com/self-hosted-configuration/#autodiscover
-  RENOVATE_AUTODISCOVER: "true"
-  # Filter out archived repositories from autodiscovery
-  # https://docs.renovatebot.com/self-hosted-configuration/#autodiscoverfilter
-  RENOVATE_AUTODISCOVER_FILTER: "/^${{ github.repository_owner }}\\/.*/"
   # Enable dry-run mode for non-main branches to preview changes (https://docs.renovatebot.com/self-hosted-configuration/#dryrun)
   # Run renovate in dry-run mode if executed in branches other than main to prevent updating versions in PRs/branches
   RENOVATE_DRY_RUN: ${{ inputs.dryRun || ( github.head_ref || github.ref_name ) != 'main' || false }}
-  # Skip archived repositories
-  # https://docs.renovatebot.com/self-hosted-configuration/#ignorearchived
-  RENOVATE_IGNORE_ARCHIVED: "true"
-  # Username for Renovate commits
-  # https://docs.renovatebot.com/self-hosted-configuration/#username
-  RENOVATE_USERNAME: ${{ github.repository_owner }}
   # keep-sorted end
 
 permissions: read-all
@@ -50,6 +38,10 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
@@ -67,4 +59,5 @@ jobs:
       - name: 💡 Self-hosted Renovate
         uses: renovatebot/github-action@693b9ef15eec82123529a37c782242f091365961 # v46.1.14
         with:
+          configurationFile: .github/renovate-global.json5
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/renovate-global.yml
+++ b/.github/workflows/renovate-global.yml
@@ -42,7 +42,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 
@@ -58,6 +58,7 @@ jobs:
           permission-checks: read
           permission-metadata: read
           permission-statuses: write
+          permission-vulnerability-alerts: read
           permission-workflows: write
 
       - name: 💡 Self-hosted Renovate
@@ -95,7 +96,7 @@ jobs:
 
       - name: Upload Renovate log
         if: always()
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: renovate-log
           path: /tmp/renovate-log.txt

--- a/.github/workflows/renovate-global.yml
+++ b/.github/workflows/renovate-global.yml
@@ -42,7 +42,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
 
@@ -95,7 +95,7 @@ jobs:
 
       - name: Upload Renovate log
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: renovate-log
           path: /tmp/renovate-log.txt

--- a/.github/workflows/renovate-global.yml
+++ b/.github/workflows/renovate-global.yml
@@ -71,8 +71,13 @@ jobs:
         with:
           configurationFile: .github/renovate-global.json5
           token: ${{ steps.app-token.outputs.token }}
+          # Override default env-regex to pass LOG_FILE* vars to the Docker container
+          # Default only passes LOG_LEVEL; LOG_FILE and LOG_FILE_LEVEL need LOG_\w+
+          # https://github.com/renovatebot/github-action#env-regex
           env-regex: "^(?:RENOVATE_\\w+|LOG_\\w+|GITHUB_COM_TOKEN|NODE_OPTIONS|(?:HTTPS?|NO)_PROXY|(?:https?|no)_proxy)$"
         env:
+          # Write Renovate logs to a file (JSON format by default) for post-processing
+          # https://docs.renovatebot.com/config-overview/#special-environment-variables
           LOG_FILE: /tmp/renovate-log.txt
           LOG_FILE_LEVEL: info
 

--- a/.github/workflows/renovate-global.yml
+++ b/.github/workflows/renovate-global.yml
@@ -17,13 +17,13 @@ env:
   # Automatically discover all repositories accessible by the token
   # https://docs.renovatebot.com/self-hosted-configuration/#autodiscover
   RENOVATE_AUTODISCOVER: "true"
-  # Filter autodiscovery to only ruzickap repositories, excluding repos without package files
+  # Filter autodiscovery to only ${{ github.repository_owner }} repositories, with a few explicit exclusions
   # https://docs.renovatebot.com/self-hosted-configuration/#autodiscoverfilter
   RENOVATE_AUTODISCOVER_FILTER: >-
     [
-    "!/^ruzickap/old_stuff$/",
-    "!/^ruzickap/ruzickovabozena\\.xvx\\.cz$/",
-    "!/^ruzickap/wizcli-terraform-test$/",
+    "!/^${{ github.repository_owner }}/old_stuff$/",
+    "!/^${{ github.repository_owner }}/ruzickovabozena\\.xvx\\.cz$/",
+    "!/^${{ github.repository_owner }}/wizcli-terraform-test$/",
     "/^${{ github.repository_owner }}\\/.*/"
     ]
   # Enable dry-run mode for non-main branches to preview changes (https://docs.renovatebot.com/self-hosted-configuration/#dryrun)

--- a/.github/workflows/renovate-global.yml
+++ b/.github/workflows/renovate-global.yml
@@ -55,6 +55,7 @@ jobs:
         with:
           client-id: ${{ secrets.MY_RENOVATE_GITHUB_CLIENT_ID }}
           private-key: ${{ secrets.MY_RENOVATE_GITHUB_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }} # zizmor: ignore[github-app]
           permission-contents: write
           permission-pull-requests: write
           permission-issues: write

--- a/.github/workflows/renovate-global.yml
+++ b/.github/workflows/renovate-global.yml
@@ -57,7 +57,33 @@ jobs:
           permission-workflows: write
 
       - name: 💡 Self-hosted Renovate
+        id: renovate
         uses: renovatebot/github-action@693b9ef15eec82123529a37c782242f091365961 # v46.1.14
         with:
           configurationFile: .github/renovate-global.json5
           token: ${{ steps.app-token.outputs.token }}
+
+      - name: Install Copilot CLI
+        if: always()
+        run: npm install -g @github/copilot
+
+      - name: Summarize Renovate output
+        if: always()
+        env:
+          COPILOT_GITHUB_TOKEN: ${{ secrets.MY_COPILOT_TOKEN }}
+          GH_TOKEN: ${{ secrets.MY_COPILOT_TOKEN }}
+        run: |
+          # Fetch the Renovate step log from the current workflow run
+          gh run view "${{ github.run_id }}" --repo "${{ github.repository }}" --log 2>&1 \
+            | grep -E "(DRY-RUN|WARN|INFO.*Would|Autodiscovered|error in)" > /tmp/renovate-log.txt || true
+
+          copilot -p "Read the file /tmp/renovate-log.txt which contains Renovate bot output logs.
+          Create a markdown summary organized by repository showing:
+          - Which repositories were processed
+          - What updates would be applied (or were applied) in each repo (branches created, PRs, automerges)
+          - Any errors or warnings encountered
+          Group updates by type: automerge, PR creation, branch commits, orphan branch cleanup, onboarding.
+          Format as clear markdown with tables and bullet lists.
+          Write the result to summary.md" \
+            --allow-tool='shell(cat:*,grep:*,wc:*)' --allow-tool=read --allow-tool=write --no-ask-user
+          cat summary.md >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/renovate-global.yml
+++ b/.github/workflows/renovate-global.yml
@@ -79,7 +79,7 @@ jobs:
           # Write Renovate logs to a file (JSON format by default) for post-processing
           # https://docs.renovatebot.com/config-overview/#special-environment-variables
           LOG_FILE: /tmp/renovate-log.txt
-          LOG_FILE_LEVEL: info
+          LOG_FILE_LEVEL: debug
 
       - name: Install Copilot CLI
         if: always()

--- a/.github/workflows/renovate-global.yml
+++ b/.github/workflows/renovate-global.yml
@@ -14,8 +14,6 @@ on:
 
 env:
   # keep-sorted start
-  # Set log level for debugging (info, debug, or trace) https://docs.renovatebot.com/troubleshooting/#log-debug-levels
-  LOG_LEVEL: info
   # Automatically discover all repositories accessible by the token
   # https://docs.renovatebot.com/self-hosted-configuration/#autodiscover
   RENOVATE_AUTODISCOVER: "true"
@@ -80,7 +78,7 @@ jobs:
         env:
           COPILOT_GITHUB_TOKEN: ${{ secrets.MY_COPILOT_TOKEN }}
         run: |
-          copilot --allow-tool='*' --no-ask-user -p "
+          copilot --prompt "
             Read the file /tmp/renovate-log.txt which contains Renovate bot output logs.
 
             Create a markdown summary organized by repository showing:
@@ -90,7 +88,7 @@ jobs:
 
             Group updates by type: automerge, PR creation, branch commits, orphan branch cleanup, onboarding.
             Format as clear markdown with tables and bullet lists.
-            Write the result to /tmp/summary.md"
+            Write the result to /tmp/summary.md" --yolo --no-ask-user --no-custom-instructions
 
           cat /tmp/summary.md >> "${GITHUB_STEP_SUMMARY}"
 

--- a/.github/workflows/renovate-global.yml
+++ b/.github/workflows/renovate-global.yml
@@ -9,21 +9,13 @@ on:
       dryRun:
         type: boolean
         description: Dry-Run
-      logLevel:
-        type: choice
-        description: Log-Level
-        default: debug
-        options:
-          - info
-          - debug
-          - trace
   # schedule:
   #   - cron: 0 4-6 * * 0
 
 env:
   # keep-sorted start
   # Set log level for debugging (info, debug, or trace) https://docs.renovatebot.com/troubleshooting/#log-debug-levels
-  LOG_LEVEL: ${{ inputs.logLevel || 'debug' }}
+  LOG_LEVEL: info
   # Enable dry-run mode for non-main branches to preview changes (https://docs.renovatebot.com/self-hosted-configuration/#dryrun)
   # Run renovate in dry-run mode if executed in branches other than main to prevent updating versions in PRs/branches
   RENOVATE_DRY_RUN: ${{ inputs.dryRun || ( github.head_ref || github.ref_name ) != 'main' || false }}
@@ -70,7 +62,7 @@ jobs:
         if: always()
         run: npm install -g @github/copilot
 
-      - name: Summarize Renovate output
+      - name: 📝 Summarize Renovate output
         if: always()
         env:
           COPILOT_GITHUB_TOKEN: ${{ secrets.MY_COPILOT_TOKEN }}
@@ -88,3 +80,11 @@ jobs:
             Write the result to /tmp/summary.md"
 
           cat /tmp/summary.md >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Upload Renovate log
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: renovate-log
+          path: /tmp/renovate-log.txt
+          retention-days: 1

--- a/.github/workflows/renovate-global.yml
+++ b/.github/workflows/renovate-global.yml
@@ -71,6 +71,7 @@ jobs:
         with:
           configurationFile: .github/renovate-global.json5
           token: ${{ steps.app-token.outputs.token }}
+          env-regex: "^(?:RENOVATE_\\w+|LOG_\\w+|GITHUB_COM_TOKEN|NODE_OPTIONS|(?:HTTPS?|NO)_PROXY|(?:https?|no)_proxy)$"
         env:
           LOG_FILE: /tmp/renovate-log.txt
           LOG_FILE_LEVEL: info

--- a/.github/workflows/renovate-global.yml
+++ b/.github/workflows/renovate-global.yml
@@ -62,6 +62,9 @@ jobs:
         with:
           configurationFile: .github/renovate-global.json5
           token: ${{ steps.app-token.outputs.token }}
+        env:
+          LOG_FILE: /tmp/renovate-log.txt
+          LOG_FILE_LEVEL: info
 
       - name: Install Copilot CLI
         if: always()
@@ -71,11 +74,7 @@ jobs:
         if: always()
         env:
           COPILOT_GITHUB_TOKEN: ${{ secrets.MY_COPILOT_TOKEN }}
-          GH_TOKEN: ${{ secrets.MY_COPILOT_TOKEN }}
         run: |
-          # Fetch the Renovate step log from the current workflow run
-          gh run view "${{ github.run_id }}" --repo "${{ github.repository }}" --log > /tmp/renovate-log.txt 2>&1 || true
-
           copilot -p "Read the file /tmp/renovate-log.txt which contains Renovate bot output logs.
           Create a markdown summary organized by repository showing:
           - Which repositories were processed

--- a/.github/workflows/renovate-global.yml
+++ b/.github/workflows/renovate-global.yml
@@ -17,12 +17,18 @@ env:
   # Automatically discover all repositories accessible by the token
   # https://docs.renovatebot.com/self-hosted-configuration/#autodiscover
   RENOVATE_AUTODISCOVER: "true"
-  # Filter autodiscovery to only ruzickap repositories
+  # Filter autodiscovery to only ruzickap repositories, excluding repos without package files
   # https://docs.renovatebot.com/self-hosted-configuration/#autodiscoverfilter
-  RENOVATE_AUTODISCOVER_FILTER: "/^${{ github.repository_owner }}\\/.*/"
+  RENOVATE_AUTODISCOVER_FILTER: >-
+    [
+    "!/^ruzickap/old_stuff$/",
+    "!/^ruzickap/ruzickovabozena\\.xvx\\.cz$/",
+    "!/^ruzickap/wizcli-terraform-test$/",
+    "/^${{ github.repository_owner }}\\/.*/"
+    ]
   # Enable dry-run mode for non-main branches to preview changes (https://docs.renovatebot.com/self-hosted-configuration/#dryrun)
   # Run renovate in dry-run mode if executed in branches other than main to prevent updating versions in PRs/branches
-  RENOVATE_DRY_RUN: ${{ inputs.dryRun || ( github.head_ref || github.ref_name ) != 'main' || false }}
+  RENOVATE_DRY_RUN: ${{ (inputs.dryRun || ( github.head_ref || github.ref_name ) != 'main') && 'full' || 'off' }}
   # Skip archived repositories
   # https://docs.renovatebot.com/self-hosted-configuration/#ignorearchived
   RENOVATE_IGNORE_ARCHIVED: "true"

--- a/.github/workflows/renovate-global.yml
+++ b/.github/workflows/renovate-global.yml
@@ -75,13 +75,16 @@ jobs:
         env:
           COPILOT_GITHUB_TOKEN: ${{ secrets.MY_COPILOT_TOKEN }}
         run: |
-          copilot -p "Read the file /tmp/renovate-log.txt which contains Renovate bot output logs.
-          Create a markdown summary organized by repository showing:
-          - Which repositories were processed
-          - What updates would be applied (or were applied) in each repo (branches created, PRs, automerges)
-          - Any errors or warnings encountered
-          Group updates by type: automerge, PR creation, branch commits, orphan branch cleanup, onboarding.
-          Format as clear markdown with tables and bullet lists.
-          Write the result to summary.md" \
-            --allow-tool='shell(cat:*,grep:*,wc:*)' --allow-tool=read --allow-tool=write --no-ask-user
-          cat summary.md >> "${GITHUB_STEP_SUMMARY}"
+          copilot --allow-tool='*' --no-ask-user -p "
+            Read the file /tmp/renovate-log.txt which contains Renovate bot output logs.
+
+            Create a markdown summary organized by repository showing:
+            - Which repositories were processed
+            - What updates would be applied (or were applied) in each repo (branches created, PRs, automerges)
+            - Any errors or warnings encountered
+
+            Group updates by type: automerge, PR creation, branch commits, orphan branch cleanup, onboarding.
+            Format as clear markdown with tables and bullet lists.
+            Write the result to /tmp/summary.md"
+
+          cat /tmp/summary.md >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -59,6 +59,7 @@ jobs:
           permission-checks: read
           permission-metadata: read
           permission-statuses: write
+          permission-vulnerability-alerts: read
           permission-workflows: write
 
       - name: 💡 Self-hosted Renovate

--- a/gh-repo-defaults/my-defaults/.github/workflows/renovate.yml
+++ b/gh-repo-defaults/my-defaults/.github/workflows/renovate.yml
@@ -59,6 +59,7 @@ jobs:
           permission-checks: read
           permission-metadata: read
           permission-statuses: write
+          permission-vulnerability-alerts: read
           permission-workflows: write
 
       - name: 💡 Self-hosted Renovate


### PR DESCRIPTION
## Problem

The `renovate-global` workflow was only discovering **1 repository** (`ruzickap/my-git-projects`) instead of all ~40+ repos because the GitHub App token was scoped only to the current repository.

The `actions/create-github-app-token` step did not specify `owner`, so the token was limited to just the repo running the workflow.

From [run #27086018133](https://github.com/ruzickap/my-git-projects/actions/runs/27086018133/job/79940533656):
```
Autodiscovered 1 repositories
```

## Fix

- Add `owner: ${{ github.repository_owner }}` to the token creation step so the token covers all repositories the GitHub App is installed on under the owner
- Add `zizmor.yml` to suppress the intentional `github-app` finding for this workflow (global Renovate requires access to all repos by design)