### PR TITLE
feat: add renovate-summary-generator repo and fix region ref

### DIFF
--- a/opentofu/cloudflare-github/github-repositories.tf
+++ b/opentofu/cloudflare-github/github-repositories.tf
@@ -48,6 +48,11 @@ locals {
         "WIZ_CLIENT_SECRET" = data.aws_ssm_parameter.github_ruzickap_pre_commit_wizcli_actions_secrets_WIZ_CLIENT_SECRET.value
       }
     }
+    "renovate_summary_generator" = {
+      name        = "renovate-summary-generator"
+      description = "Create a Markdown summary by parsing Renovate debug log"
+      topics      = ["renovate", "log", "parser", "debug", "public", "markdown"]
+    }
     "wiz_certification_notes" = {
       name        = "wiz-certification-notes"
       description = "Wiz Certified exams Notes"

--- a/opentofu/cloudflare-github/main.tf
+++ b/opentofu/cloudflare-github/main.tf
@@ -84,7 +84,7 @@ locals {
   # Name of the Cloudflare API token to manage
   opentofu_cloudflare_github_api_token_name = "opentofu-cloudflare-github (ruzickap/my-git-projects/opentofu/cloudflare-github)"
   # ARN prefix for SSM parameters — used by ephemeral resources which require ARN instead of name (https://github.com/hashicorp/terraform-provider-aws/issues/40623)
-  ssm_parameter_arn_prefix = "arn:aws:ssm:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:parameter"
+  ssm_parameter_arn_prefix = "arn:aws:ssm:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:parameter"
   # keep-sorted end
 }
 


### PR DESCRIPTION
## Changes

- Add `renovate_summary_generator` repository definition with topics
  (`renovate`, `log`, `parser`, `debug`, `public`, `markdown`)
- Fix `data.aws_region.current` attribute from `.id` to `.region` in SSM
  parameter ARN prefix