### PR TITLE
fix: correct workflow defaults for cache, colors, and stale timings

### DIFF
--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Save lychee cache
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        if: always() && steps.restore-cache.outputs.cache-primary-key
+        if: always() && steps.restore-cache.outputs.cache-hit != 'true'
         with:
           path: .lycheecache
           key: ${{ steps.restore-cache.outputs.cache-primary-key }}

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Save lychee cache
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        if: always() && steps.restore-cache.outputs.cache-hit != 'true'
+        if: always() && steps.restore-cache.outputs.cache-primary-key && steps.restore-cache.outputs.cache-hit != 'true'
         with:
           path: .lycheecache
           key: ${{ steps.restore-cache.outputs.cache-primary-key }}

--- a/.github/workflows/pr-slack-notification.yml
+++ b/.github/workflows/pr-slack-notification.yml
@@ -136,7 +136,7 @@ jobs:
             ts: "${{ env.SLACK_TIMESTAMP }}"
             text: "✅ *${{ github.event.pull_request.user.login }}*: <${{ github.event.repository.html_url }}|${{ github.repository }}> - <${{ github.event.pull_request.html_url }}|#${{ github.event.pull_request.number }} - ${{ github.event.pull_request.title }}> (+${{ github.event.pull_request.additions }}, -${{ github.event.pull_request.deletions }})"
             attachments:
-              - color: "28a745"
+              - color: "#28a745"
                 fields:
                   - title: "Status"
                     short: true
@@ -153,7 +153,7 @@ jobs:
             ts: "${{ env.SLACK_TIMESTAMP }}"
             text: "❎ *${{ github.event.pull_request.user.login }}*: <${{ github.event.repository.html_url }}|${{ github.repository }}> - <${{ github.event.pull_request.html_url }}|#${{ github.event.pull_request.number }} - ${{ github.event.pull_request.title }}> (+${{ github.event.pull_request.additions }}, -${{ github.event.pull_request.deletions }})"
             attachments:
-              - color: "fa7015"
+              - color: "#fa7015"
                 fields:
                   - title: "Status"
                     short: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -25,7 +25,7 @@ jobs:
 
             If this issue is still relevant, please reopen it or create a new issue with updated information.
           close-pr-message: |
-            This pull request has been automatically closed because it has been stale for 14 days with no activity.
+            This pull request has been automatically closed because it has been stale for 7 days with no activity.
 
             If this pull request is still relevant, please reopen it or rebase and push new commits.
           stale-issue-label: stale
@@ -40,7 +40,7 @@ jobs:
             This issue will be automatically closed in 7 days if no further activity occurs.
           stale-pr-label: stale
           stale-pr-message: |
-            This pull request is stale because it has been open for 30 days with no activity.
+            This pull request is stale because it has been open for 60 days with no activity.
 
             Please:
             - Add a comment if this PR is still relevant
@@ -48,5 +48,5 @@ jobs:
             - Remove the stale label if you need more time
             - Close the PR if it's no longer needed
 
-            This pull request will be automatically closed in 14 days if no further activity occurs.
+            This pull request will be automatically closed in 7 days if no further activity occurs.
           # keep-sorted end

--- a/gh-repo-defaults/my-defaults/.github/workflows/mega-linter.yml
+++ b/gh-repo-defaults/my-defaults/.github/workflows/mega-linter.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Save lychee cache
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        if: always() && steps.restore-cache.outputs.cache-primary-key
+        if: always() && steps.restore-cache.outputs.cache-hit != 'true'
         with:
           path: .lycheecache
           key: ${{ steps.restore-cache.outputs.cache-primary-key }}

--- a/gh-repo-defaults/my-defaults/.github/workflows/mega-linter.yml
+++ b/gh-repo-defaults/my-defaults/.github/workflows/mega-linter.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Save lychee cache
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        if: always() && steps.restore-cache.outputs.cache-hit != 'true'
+        if: always() && steps.restore-cache.outputs.cache-primary-key && steps.restore-cache.outputs.cache-hit != 'true'
         with:
           path: .lycheecache
           key: ${{ steps.restore-cache.outputs.cache-primary-key }}

--- a/gh-repo-defaults/my-defaults/.github/workflows/pr-slack-notification.yml
+++ b/gh-repo-defaults/my-defaults/.github/workflows/pr-slack-notification.yml
@@ -136,7 +136,7 @@ jobs:
             ts: "${{ env.SLACK_TIMESTAMP }}"
             text: "✅ *${{ github.event.pull_request.user.login }}*: <${{ github.event.repository.html_url }}|${{ github.repository }}> - <${{ github.event.pull_request.html_url }}|#${{ github.event.pull_request.number }} - ${{ github.event.pull_request.title }}> (+${{ github.event.pull_request.additions }}, -${{ github.event.pull_request.deletions }})"
             attachments:
-              - color: "28a745"
+              - color: "#28a745"
                 fields:
                   - title: "Status"
                     short: true
@@ -153,7 +153,7 @@ jobs:
             ts: "${{ env.SLACK_TIMESTAMP }}"
             text: "❎ *${{ github.event.pull_request.user.login }}*: <${{ github.event.repository.html_url }}|${{ github.repository }}> - <${{ github.event.pull_request.html_url }}|#${{ github.event.pull_request.number }} - ${{ github.event.pull_request.title }}> (+${{ github.event.pull_request.additions }}, -${{ github.event.pull_request.deletions }})"
             attachments:
-              - color: "fa7015"
+              - color: "#fa7015"
                 fields:
                   - title: "Status"
                     short: true

--- a/gh-repo-defaults/my-defaults/.github/workflows/stale.yml
+++ b/gh-repo-defaults/my-defaults/.github/workflows/stale.yml
@@ -25,7 +25,7 @@ jobs:
 
             If this issue is still relevant, please reopen it or create a new issue with updated information.
           close-pr-message: |
-            This pull request has been automatically closed because it has been stale for 14 days with no activity.
+            This pull request has been automatically closed because it has been stale for 7 days with no activity.
 
             If this pull request is still relevant, please reopen it or rebase and push new commits.
           stale-issue-label: stale
@@ -40,7 +40,7 @@ jobs:
             This issue will be automatically closed in 7 days if no further activity occurs.
           stale-pr-label: stale
           stale-pr-message: |
-            This pull request is stale because it has been open for 30 days with no activity.
+            This pull request is stale because it has been open for 60 days with no activity.
 
             Please:
             - Add a comment if this PR is still relevant
@@ -48,5 +48,5 @@ jobs:
             - Remove the stale label if you need more time
             - Close the PR if it's no longer needed
 
-            This pull request will be automatically closed in 14 days if no further activity occurs.
+            This pull request will be automatically closed in 7 days if no further activity occurs.
           # keep-sorted end


### PR DESCRIPTION
## Summary

- **mega-linter.yml**: Only save lychee cache when `cache-hit != 'true'` (avoids redundant cache writes)
- **pr-slack-notification.yml**: Add missing `#` prefix to hex color codes in Slack attachments
- **stale.yml**: Mark PRs stale after 60 days (was 30), auto-close after 7 days (was 14)

Both root and `gh-repo-defaults/my-defaults/` copies updated to stay in sync.