### PR TITLE
fix: add requireConfig optional for repos without config

### DIFF
--- a/.github/renovate-global.json5
+++ b/.github/renovate-global.json5
@@ -201,6 +201,9 @@
   // Rebase branches when they fall behind the base branch
   // https://docs.renovatebot.com/configuration-options/#rebasewhen
   rebaseWhen: "behind-base-branch",
+  // Process repositories even without a local Renovate config file
+  // https://docs.renovatebot.com/self-hosted-configuration/#requireconfig
+  requireConfig: "optional",
   // Create separate branches for minor and patch updates
   // https://docs.renovatebot.com/configuration-options/#separateminorpatch
   separateMinorPatch: true,

--- a/.github/workflows/renovate-global.yml
+++ b/.github/workflows/renovate-global.yml
@@ -54,6 +54,7 @@ jobs:
         env:
           # Write Renovate logs to a file - https://docs.renovatebot.com/config-overview/#logging-variables
           LOG_FILE: /tmp/renovate-log.json
+          LOG_LEVEL: debug
 
       - name: Upload Renovate log
         if: always()

--- a/gh-repo-defaults/my-defaults/.github/workflows/mega-linter.yml
+++ b/gh-repo-defaults/my-defaults/.github/workflows/mega-linter.yml
@@ -16,7 +16,7 @@ jobs:
   mega-linter:
     runs-on: ubuntu-latest
     if: ${{ (!startsWith(github.ref_name, 'chore/renovate/') && !startsWith(github.ref_name, 'release-please--')) || github.event_name == 'workflow_dispatch' }}
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       - name: Checkout Code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
Repos without a local `renovate.json` were showing `disabled-no-config` status because Renovate requires a config file by default.

## Changes

- Add `requireConfig: "optional"` to `.github/renovate-global.json5` so Renovate processes all repos using the global config without needing per-repo config files
- Set `LOG_LEVEL=debug` in renovate-global workflow for better troubleshooting
- Increase mega-linter timeout from 10 to 20 minutes to prevent timeouts in larger repositories