### PR TITLE
chore: update renovate logging and github.io repo secrets

### DIFF
--- a/.github/workflows/renovate-global.yml
+++ b/.github/workflows/renovate-global.yml
@@ -54,7 +54,6 @@ jobs:
         env:
           # Write Renovate logs to a file - https://docs.renovatebot.com/config-overview/#logging-variables
           LOG_FILE: /tmp/renovate-log.json
-          LOG_LEVEL: debug
 
       - name: Upload Renovate log
         if: always()

--- a/opentofu/cloudflare-github/aws.tf
+++ b/opentofu/cloudflare-github/aws.tf
@@ -94,6 +94,11 @@ data "aws_ssm_parameter" "github_ruzickap_ruzickap_github_io_actions_secrets_MY_
   with_decryption = true
 }
 
+data "aws_ssm_parameter" "github_ruzickap_ruzickap_github_io_actions_secrets_MY_SLACK_BOT_SIGNING_SECRET" {
+  name            = "/github/ruzickap/ruzickap.github.io/actions-secrets/MY_SLACK_BOT_SIGNING_SECRET"
+  with_decryption = true
+}
+
 data "aws_ssm_parameter" "github_shared_actions_secrets_MY_RENOVATE_GITHUB_CLIENT_ID" {
   name            = "/github/shared/actions-secrets/MY_RENOVATE_GITHUB_CLIENT_ID"
   with_decryption = true

--- a/opentofu/cloudflare-github/github-repositories.tf
+++ b/opentofu/cloudflare-github/github-repositories.tf
@@ -199,13 +199,13 @@ locals {
       topics = ["blog", "github", "github-actions", "jekyll", "markdown", "personal-website", "public", "web", "website"]
       secrets = {
         # keep-sorted start
-        "CLOUDFLARE_ACCOUNT_ID"               = local.cloudflare_account_id
-        "CLOUDFLARE_API_TOKEN"                = cloudflare_account_token.pages_ruzickap_github_io.value
+        # .github/workflows/gh-pages-build.yml
         "CLOUDFLARE_WEB_ANALYTICS_SITE_TOKEN" = cloudflare_web_analytics_site.ruzickap_github_io.site_token
         "GOOGLE_CLIENT_ID"                    = data.aws_ssm_parameter.github_ruzickap_ruzickap_github_io_actions_secrets_GOOGLE_CLIENT_ID.value
         "GOOGLE_CLIENT_SECRET"                = data.aws_ssm_parameter.github_ruzickap_ruzickap_github_io_actions_secrets_GOOGLE_CLIENT_SECRET.value
-        "MY_ATLASSIAN_PERSONAL_TOKEN"         = data.aws_ssm_parameter.github_ruzickap_ruzickap_github_io_actions_secrets_MY_ATLASSIAN_PERSONAL_TOKEN.value
-        "RUZICKA_SBX01_AWS_ROLE_TO_ASSUME"    = data.aws_ssm_parameter.github_shared_actions_secrets_RUZICKA_SBX01_AWS_ROLE_TO_ASSUME.value
+        # .github/workflows/docs-confluence-sync.yml
+        "MY_ATLASSIAN_PERSONAL_TOKEN" = data.aws_ssm_parameter.github_ruzickap_ruzickap_github_io_actions_secrets_MY_ATLASSIAN_PERSONAL_TOKEN.value
+        "MY_SLACK_BOT_SIGNING_SECRET" = data.aws_ssm_parameter.github_ruzickap_ruzickap_github_io_actions_secrets_MY_SLACK_BOT_SIGNING_SECRET.value
         # keep-sorted end
       }
     }


### PR DESCRIPTION
## Changes

- Remove `LOG_LEVEL: debug` from `renovate-global` workflow (no longer needed)
- Add `MY_SLACK_BOT_SIGNING_SECRET` SSM parameter for `ruzickap.github.io`
- Remove unused Cloudflare and AWS secrets from `ruzickap.github.io` repository config
- Add workflow file comments for secret usage context