### PR TITLE
feat: add cloudflare pages secrets for ruzickap.github.io

### DIFF
--- a/opentofu/cloudflare-github/github-repositories.tf
+++ b/opentofu/cloudflare-github/github-repositories.tf
@@ -199,7 +199,9 @@ locals {
       topics = ["blog", "github", "github-actions", "jekyll", "markdown", "personal-website", "public", "web", "website"]
       secrets = {
         # keep-sorted start
-        # .github/workflows/gh-pages-build.yml
+        # .github/workflows/gh-pages-build.yml (Cloudflare Pages + Analytics)
+        "CLOUDFLARE_ACCOUNT_ID"               = local.cloudflare_account_id
+        "CLOUDFLARE_API_TOKEN"                = cloudflare_account_token.pages_ruzickap_github_io.value
         "CLOUDFLARE_WEB_ANALYTICS_SITE_TOKEN" = cloudflare_web_analytics_site.ruzickap_github_io.site_token
         "GOOGLE_CLIENT_ID"                    = data.aws_ssm_parameter.github_ruzickap_ruzickap_github_io_actions_secrets_GOOGLE_CLIENT_ID.value
         "GOOGLE_CLIENT_SECRET"                = data.aws_ssm_parameter.github_ruzickap_ruzickap_github_io_actions_secrets_GOOGLE_CLIENT_SECRET.value


### PR DESCRIPTION
## What

Add `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN` GitHub Actions
secrets to the `ruzickap.github.io` repository.

## Why

The `.github/workflows/gh-pages-build.yml` workflow needs these
credentials to deploy the site to Cloudflare Pages. The API token is
sourced from the existing `cloudflare_account_token.pages_ruzickap_github_io`
resource.

## Notes

This touches live infrastructure (the `cloudflare-github` module).
CI applies it on push to `main` or on PRs labeled `tofu-apply`.