### PR TITLE
feat: add renovate report and upload it as artifact

### DIFF
--- a/.github/workflows/renovate-global.yml
+++ b/.github/workflows/renovate-global.yml
@@ -54,6 +54,9 @@ jobs:
         env:
           # Write Renovate logs to a file - https://docs.renovatebot.com/config-overview/#logging-variables
           LOG_FILE: /tmp/renovate-log.json
+          # Write a Renovate report to a file - https://docs.renovatebot.com/self-hosted-configuration/#reporttype
+          RENOVATE_REPORT_TYPE: file
+          RENOVATE_REPORT_PATH: /tmp/renovate-report.json
 
       - name: Upload Renovate log
         if: always()
@@ -61,6 +64,16 @@ jobs:
         with:
           name: renovate-log
           path: /tmp/renovate-log.json
+          if-no-files-found: error
+          compression-level: 9
+          retention-days: 1
+
+      - name: Upload Renovate report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: renovate-report
+          path: /tmp/renovate-report.json
           if-no-files-found: error
           compression-level: 9
           retention-days: 1


### PR DESCRIPTION
## What

Enable Renovate's native report generation in the `renovate-global`
workflow and upload the resulting JSON report as a GitHub Actions
artifact.

## Why

The workflow already uploads the raw Renovate **log**, but not the
structured **report**. The report is a concise, machine-readable
summary of what Renovate did across all repositories, which is far
easier to inspect than the full debug log.

## How

- Set the self-hosted options
  [`reportType: file`](https://docs.renovatebot.com/self-hosted-configuration/#reporttype)
  and `reportPath` via `RENOVATE_REPORT_TYPE` / `RENOVATE_REPORT_PATH`
  env vars on the Renovate step. The existing `env-regex` already
  forwards `RENOVATE_*` vars into the container, so no regex change is
  needed.
- Add an `Upload Renovate report` step using `actions/upload-artifact`,
  mirroring the existing `Upload Renovate log` step (same pinned SHA,
  `if: always()`, compression, and 1-day retention).

## Notes

- Validated locally with `actionlint` and `yamllint`; all pre-commit
  hooks pass.