### PR TITLE
fix: disable digest pinning for custom regex Docker deps

### DIFF
--- a/.github/renovate-global.json5
+++ b/.github/renovate-global.json5
@@ -163,6 +163,16 @@
       pinDigests: false,
     },
     {
+      // The custom regex manager cannot write a digest back into values that
+      // have no digest placeholder, so docker:pinDigests produces an empty
+      // "pin" update and fails with "Error updating branch: update failure".
+      // Disable digest pinning for Docker deps handled by the custom manager.
+      description: "Custom regex manager can't pin Docker digests; only bump versions",
+      matchManagers: ["custom.regex"],
+      matchDatasources: ["docker"],
+      pinDigests: false,
+    },
+    {
       description: "Skip renovating _posts directory in ruzickap.github.io",
       matchRepositories: ["ruzickap/ruzickap.github.io"],
       matchFileNames: ["_posts/**"],


### PR DESCRIPTION
## Motivation

Renovate's `pin-dependencies` branch fails for repositories whose Docker
dependencies are tracked via the shared **custom regex manager** (the
`# renovate: datasource=docker depName=...` comment style).

Example from the latest Renovate run (`ruzickap/ansible-openwrt`,
`.github/workflows/ansible-openwrt-test.yml`):

```text
Found match at index 404            depName=openwrt/rootfs
Digest is not updated               expectedValue=sha256:b4fa...  (manager=regex)
Error updating branch: update failure   (branch=chore/renovate/pin-dependencies)
```

### Root cause

- The global config extends `docker:pinDigests`.
- For a `docker` datasource dep, Renovate generates a **pin** update to
  append `@sha256:...` to the value.
- The custom regex manager's `matchStrings` only captures `currentValue`
  (no `currentDigest` group), and the value (e.g. `"x86_64-25.12.2"`) has
  no digest placeholder to write into.
- Result: `getUpdatedPackageFiles()` produces no change → "Digest is not
  updated" → "update failure".

This is a known Renovate limitation — the custom/regex manager cannot
*introduce* a brand-new digest. The same failure recurs across multiple
repos in the autodiscover set.

## Change

Add a `packageRules` entry that disables `pinDigests` for Docker deps
handled by the `custom.regex` manager (mirroring the existing
`slsa-framework/...` `pinDigests: false` precedent).

- Real Docker / Dockerfile / Compose managers keep digest pinning.
- Normal version bumps for custom-manager Docker deps continue to work.
- Fixes the recurring `chore/renovate/pin-dependencies` failures.

## Validation

- `npx json5 .github/renovate-global.json5` parses successfully.