### PR TITLE
chore: remove renovate-summary-generator repo from cloudflare-github

### DIFF
--- a/opentofu/cloudflare-github/github-repositories.tf
+++ b/opentofu/cloudflare-github/github-repositories.tf
@@ -48,11 +48,6 @@ locals {
         "WIZ_CLIENT_SECRET" = data.aws_ssm_parameter.github_ruzickap_pre_commit_wizcli_actions_secrets_WIZ_CLIENT_SECRET.value
       }
     }
-    "renovate_summary_generator" = {
-      name        = "renovate-summary-generator"
-      description = "Create a Markdown summary by parsing Renovate debug log"
-      topics      = ["renovate", "log", "parser", "debug", "public", "markdown"]
-    }
     "wiz_certification_notes" = {
       name        = "wiz-certification-notes"
       description = "Wiz Certified exams Notes"


### PR DESCRIPTION
## What

Removes the `renovate_summary_generator` entry from the `cloudflare-github` OpenTofu module (`opentofu/cloudflare-github/github-repositories.tf`).

## Why

This module should no longer manage the GitHub repository configuration for `renovate-summary-generator`.

## Impact

- This touches a **live infrastructure** module. On merge to `main` (or on a PR labeled `tofu-apply`), CI will run `tofu apply` and stop managing this repository's config.
- Please review the CI `tofu plan` output before merging.

> [!NOTE]
> A reference still exists in `multi-gitter/multi-gitter-run-script.sh` (line 140); intentionally left untouched in this PR.