### PR TITLE
fix: match regex manager so docker pin-digests is skipped

### DIFF
--- a/.github/renovate-global.json5
+++ b/.github/renovate-global.json5
@@ -167,8 +167,10 @@
       // have no digest placeholder, so docker:pinDigests produces an empty
       // "pin" update and fails with "Error updating branch: update failure".
       // Disable digest pinning for Docker deps handled by the custom manager.
+      // Renovate reports this manager as "regex" (not "custom.regex") in the
+      // run report/logs, so match both names to stay version-proof.
       description: "Custom regex manager can't pin Docker digests; only bump versions",
-      matchManagers: ["custom.regex"],
+      matchManagers: ["custom.regex", "regex"],
       matchDatasources: ["docker"],
       pinDigests: false,
     },


### PR DESCRIPTION
## Problem

Three repos reported `Error updating branch: update failure` on their
`chore/renovate/pin-dependencies` branch in the latest `renovate-global`
run ([run 27472437848](https://github.com/ruzickap/my-git-projects/actions/runs/27472437848)):

- `ruzickap/ansible-openwrt`
- `ruzickap/ruzickap.github.io`
- `ruzickap/malware-cryptominer-container`

## Root cause

The `renovate-log` artifact shows each failure is preceded by
`"manager":"regex"` ... `"Digest is not updated"`:

| Repo | Dep | File | Offending reference (no `@sha256:`) |
| --- | --- | --- | --- |
| ansible-openwrt | `openwrt/rootfs` | `.github/workflows/ansible-openwrt-test.yml` | `openwrt/rootfs:${OPENWRT_VERSION}` |
| ruzickap.github.io | `nginxinc/nginx-unprivileged` | `Dockerfile` | `LABEL ...base.name="nginxinc/nginx-unprivileged:1.31.1-alpine-slim"` |
| malware-cryptominer-container | `nginxinc/nginx-unprivileged` | `Dockerfile` | same LABEL pattern |

The existing rule that disables digest pinning for Docker deps handled by
the custom regex manager used `matchManagers: ["custom.regex"]`. But in
the actual run the manager is reported as `regex`, so the rule never
matched. `docker:pinDigests` then tried to pin a digest the custom regex
manager cannot write back into a version-only reference, producing the
`update failure`.

## Fix

Match both `custom.regex` and `regex` so the rule applies at runtime
regardless of the manager name Renovate emits. One rule covers all three
repos because it keys on manager + datasource, not repository.

## Validation

`renovate-config-validator` (pinned to the run's version, 43.220.0)
reports `Config validated successfully` (exit 0).

## Verify after merge

Re-run the `renovate-global` workflow (optionally with Dry-Run) and
confirm the three `update failure` warnings are gone.