### PR TITLE
feat: capture docker digest in custom regex manager

### DIFF
--- a/.github/renovate-global.json5
+++ b/.github/renovate-global.json5
@@ -60,8 +60,12 @@
       // Regex pattern to match custom dependency declarations
       // Format: # renovate: datasource=<source> depName=<name> [versioning=<type>] [extractVersion=<regex>] [registryUrl=<url>]
       // Example: # renovate: datasource=github-releases depName=helm/helm versioning=semver
+      // The optional "@sha256:<digest>" suffix is captured as currentDigest so
+      // pinned references (e.g. an OCI base-image LABEL) produce a writable
+      // "digest" update instead of a failing "pinDigest". [^@\n]* stops the
+      // value scan before the digest so currentValue excludes it.
       matchStrings: [
-        '# renovate: datasource=(?<datasource>.+?) depName=(?<depName>.+?)( versioning=(?<versioning>.+?))?( extractVersion=(?<extractVersion>.+?))?( registryUrl=(?<registryUrl>.+?))?\\s.*[=:]\\s*"?(?<currentValue>.+?)"?\\s',
+        '# renovate: datasource=(?<datasource>.+?) depName=(?<depName>.+?)( versioning=(?<versioning>.+?))?( extractVersion=(?<extractVersion>.+?))?( registryUrl=(?<registryUrl>.+?))?\\s[^@\\n]*[=:]\\s*"?(?<currentValue>.+?)(?:@(?<currentDigest>sha256:[0-9a-f]+))?"?\\s',
       ],
 
       // Default to semantic versioning unless specified otherwise

--- a/.github/renovate-global.json5
+++ b/.github/renovate-global.json5
@@ -63,9 +63,11 @@
       // The optional "@sha256:<digest>" suffix is captured as currentDigest so
       // pinned references (e.g. an OCI base-image LABEL) produce a writable
       // "digest" update instead of a failing "pinDigest". [^@\n]* stops the
-      // value scan before the digest so currentValue excludes it.
+      // value scan before the digest so currentValue excludes it. The digest
+      // is constrained to exactly 64 hex chars so truncated/invalid strings
+      // are not mistaken for a digest.
       matchStrings: [
-        '# renovate: datasource=(?<datasource>.+?) depName=(?<depName>.+?)( versioning=(?<versioning>.+?))?( extractVersion=(?<extractVersion>.+?))?( registryUrl=(?<registryUrl>.+?))?\\s[^@\\n]*[=:]\\s*"?(?<currentValue>.+?)(?:@(?<currentDigest>sha256:[0-9a-f]+))?"?\\s',
+        '# renovate: datasource=(?<datasource>.+?) depName=(?<depName>.+?)( versioning=(?<versioning>.+?))?( extractVersion=(?<extractVersion>.+?))?( registryUrl=(?<registryUrl>.+?))?\\s[^@\\n]*[=:]\\s*"?(?<currentValue>.+?)(?:@(?<currentDigest>sha256:[0-9a-f]{64}))?"?\\s',
       ],
 
       // Default to semantic versioning unless specified otherwise


### PR DESCRIPTION
## Problem

Three repos failed their \`chore/renovate/pin-dependencies\` branch with
\`Error updating branch: update failure\` ([run 27472437848](https://github.com/ruzickap/my-git-projects/actions/runs/27472437848)).

Root cause (traced via the run's \`renovate-log\` artifact and Renovate
source \`lib/workers/repository/process/lookup\`): the custom regex
manager captured only \`currentValue\`. For a pinned OCI base-image
reference in a \`LABEL\` (\`image:TAG@sha256:...\`) there was no digest
slot, so with \`docker:pinDigests\` enabled Renovate generated a
\`pinDigest\` update it could not write back. A \`pinDigests: false\`
\`packageRule\` cannot fix this because the \`pinDigest\` update is created
at extraction time, before \`packageRules\` apply.

## Fix

Capture an optional \`@sha256:<digest>\` suffix as \`currentDigest\` so such
references produce a writable \`digest\` update instead. The value scan is
bounded with \`[^@\n]*\` so \`currentValue\` stops before the digest.

\`\`\`diff
-  ...\s.*[=:]\s*"?(?<currentValue>.+?)"?\s
+  ...\s[^@\n]*[=:]\s*"?(?<currentValue>.+?)(?:@(?<currentDigest>sha256:[0-9a-f]+))?"?\s
\`\`\`

## Validation

- \`renovate-config-validator\` (v43.220.0): \`Config validated successfully\`.
- Regression-tested against **138 real annotations** from the run
  report: \`currentValue\` parsing is **identical** for every existing
  dependency (0 regressions, 0 new match failures); the new group only
  adds digest capture where a digest is present.

## Companion PRs (add the digest to the LABELs)

- ruzickap/ruzickap.github.io: \`feat/renovate-pin-base-image-label-digest\`
- ruzickap/malware-cryptominer-container: \`feat/renovate-pin-base-image-label-digest\`

## Not covered here

\`ansible-openwrt\` uses a docker tag in a plain env var
(\`OPENWRT_VERSION\`) with no digest slot and should not be digest-pinned;
that one is handled separately.