### PR TITLE
fix: skip digest pin for openwrt/rootfs env var

### DIFF
--- a/.github/renovate-global.json5
+++ b/.github/renovate-global.json5
@@ -179,6 +179,20 @@
       pinDigests: false,
     },
     {
+      // ansible-openwrt stores the OpenWrt image tag in a plain env var
+      // (OPENWRT_VERSION), used as "openwrt/rootfs:${OPENWRT_VERSION}". There is
+      // no "@sha256:" placeholder to write a digest into, so docker:pinDigests
+      // produces a pinDigest update that fails with "Error updating branch:
+      // update failure". The custom-regex pinDigests:false rule above does not
+      // reliably suppress it here, so disable the digest/pin update types for
+      // this dependency directly (version bumps are unaffected).
+      description: "openwrt/rootfs has no digest slot (env var); skip digest pin",
+      matchRepositories: ["ruzickap/ansible-openwrt"],
+      matchPackageNames: ["openwrt/rootfs"],
+      matchUpdateTypes: ["pinDigest", "digest"],
+      enabled: false,
+    },
+    {
       description: "Skip renovating _posts directory in ruzickap.github.io",
       matchRepositories: ["ruzickap/ruzickap.github.io"],
       matchFileNames: ["_posts/**"],


### PR DESCRIPTION
## Problem

`ruzickap/ansible-openwrt` keeps failing its `chore/renovate/pin-dependencies`
branch with `Error updating branch: update failure`. Confirmed across three
consecutive `renovate-global` runs, including after #362 merged:
[27472437848](https://github.com/ruzickap/my-git-projects/actions/runs/27472437848),
[27474128994](https://github.com/ruzickap/my-git-projects/actions/runs/27474128994),
[27474791003](https://github.com/ruzickap/my-git-projects/actions/runs/27474791003).

The OpenWrt image tag lives in a plain env var:

```yaml
# renovate: datasource=docker depName=openwrt/rootfs
OPENWRT_VERSION: "x86_64-25.12.2"   # used as openwrt/rootfs:${OPENWRT_VERSION}
```

There is no `@sha256:` placeholder to write a digest into, so
`docker:pinDigests` generates a `pinDigest` update the custom regex manager
cannot apply → `"Digest is not updated"` → branch update fails.

## Why not the existing rule?

The existing `custom.regex` + docker `pinDigests:false` rule suppresses this in
local Renovate runs (Node 24) but **not** in the self-hosted run — the
`pinDigest` is still generated in production despite the rule resolving to
`pinDigests=false` via `applyPackageRules`. #362 (which changed the regex
`matchStrings`, invalidating the cached extraction) did not resolve it either,
ruling out a stale cache.

So instead of relying on the `pinDigests` flag, this disables the
`pinDigest`/`digest` update types for this dependency directly, which filters
the failing update out regardless of how `pinDigests` resolves.

## Scope & verification

```json5
{
  matchRepositories: ["ruzickap/ansible-openwrt"],
  matchPackageNames: ["openwrt/rootfs"],
  matchUpdateTypes: ["pinDigest", "digest"],
  enabled: false,
}
```

- `renovate-config-validator` (v43.220.0): **Config validated successfully**.
- Verified via Renovate `applyPackageRules`: the openwrt `pinDigest` update
  resolves to `enabled=false`, while a `minor` update stays enabled and the
  same dep in a different repo is unaffected (correctly scoped).
- Full local run: no regression (openwrt `updates: []`, no config errors).

### Known limitation

The end-to-end `pinDigest` failure **cannot be reproduced locally** — anonymous
Docker Hub digest lookups behave differently from the GitHub-hosted runner, so
locally the pin is never generated. The fix is therefore validated at the
rule-matching level (`applyPackageRules`) rather than end-to-end. Confirmation
will come from the next `renovate-global` run.

## Note on version updates

This only disables digest/pin updates. `openwrt/rootfs` still wouldn't receive
version bumps because its `semver` versioning can't parse `x86_64-25.12.2`; a
separate `versioning=docker extractVersion=^x86_64-(?<version>.+)$` change would
be needed for that (not included here).