### PR TITLE
chore: shorten docker digest commit subject to fit 72-char limit

### DIFF
--- a/.github/renovate-global.json5
+++ b/.github/renovate-global.json5
@@ -135,6 +135,17 @@
       automerge: false,
     },
     {
+      // The default Docker digest commit subject includes the image tag
+      // (e.g. "nginxinc/nginx-unprivileged:1.31.1-alpine-slim docker digest
+      // to ..."), which can exceed the 72-char commit-check limit and blocks
+      // automerge. Drop the tag from the topic (the PR body still shows the
+      // full currentValue) so the subject stays well under 72 characters.
+      description: "Shorten Docker digest commit subject to fit 72-char limit",
+      matchDatasources: ["docker"],
+      matchUpdateTypes: ["digest"],
+      commitMessageTopic: "{{{depName}}} digest",
+    },
+    {
       description: "Ignore frequent renovate updates",
       enabled: false,
       matchPackageNames: ["renovatebot/github-action"],


### PR DESCRIPTION
## What

Add a fleet-wide `packageRules` entry in `.github/renovate-global.json5`
that overrides `commitMessageTopic` for Docker **digest** updates, dropping
the image tag (`:currentValue`) from the commit *subject* only.

```json5
{
  description: "Shorten Docker digest commit subject to fit 72-char limit",
  matchDatasources: ["docker"],
  matchUpdateTypes: ["digest"],
  commitMessageTopic: "{{{depName}}} digest",
}
```

## Why

The default Renovate Docker digest commit subject embeds the image tag, e.g.:

| | Subject | Length |
|---|---|---|
| Before | `chore(deps): update nginxinc/nginx-unprivileged:1.31.1-alpine-slim docker digest to 6616de6` | **91** |
| After | `chore(deps): update nginxinc/nginx-unprivileged digest to 6616de6` | **65** |

The 91-char subject exceeds the `commit-check` `CCHK_SUBJECT_MAX_LENGTH: 72`
limit, so the required `commit-check` status fails, the PR is reported
`BLOCKED`, and Renovate cannot automerge it. This was observed on
ruzickap/malware-cryptominer-container#205.

Dropping the tag from the *topic* keeps the subject at 65 chars (7 chars of
headroom under the limit), while the PR body table still shows the full
`currentValue` tag and the `currentDigest -> newDigest` change, so no
information is lost.

## Scope / notes

- This is the single **centralized** Renovate config consumed by the
  `renovate-global` workflow; there is no `gh-repo-defaults/` copy, so the
  change applies to all autodiscovered repos with no drift to sync.
- It does **not** retroactively rewrite the existing PR #205 subject;
  Renovate will regenerate that branch on its next run with the shorter
  subject (by which point the `renovate/stability-days` gate has also
  elapsed), unblocking `commit-check` and allowing automerge.