### PR TITLE
refactor: drop not-scheduled category from renovate summary

### DIFF
--- a/scripts/renovate-summary/README.md
+++ b/scripts/renovate-summary/README.md
@@ -12,7 +12,7 @@ linked back to GitHub.
 ## Features
 
 - **Action-oriented grouping** — branches are bucketed by what Renovate
-  actually did (Error, PR opened, Pending, Not scheduled, No work, Merged),
+  actually did (Error, PR opened, Pending, No work, Merged),
   ordered so the items needing the most attention come first.
 - **Problems table** — every problem Renovate reported (deduplicated), with
   severity level, affected branch, and message.
@@ -97,11 +97,10 @@ The generated Markdown contains the following sections, in order:
    branch automerge.
 7. **🚦 Limited (rate/limit reached)** — deferred because a Renovate limit was
    reached (PR/branch/commit/group-size).
-8. **⏰ Not scheduled** — skipped, outside the schedule window.
-9. **💤 No work** — nothing to do this run.
-10. **❓ Unknown** — branches whose `result` did not map to any known category,
-    listed so nothing is silently dropped.
-11. **📊 Totals** — aggregate counts.
+8. **💤 No work** — nothing to do this run.
+9. **❓ Unknown** — branches whose `result` did not map to any known category,
+   listed so nothing is silently dropped.
+10. **📊 Totals** — aggregate counts.
 
 Each action section is preceded by a one-line description of what the category
 means. Empty categories render `_None._`.
@@ -144,7 +143,6 @@ values:
 | Pending        | `pending`; or `done` + `prBlockedBy: BranchAutomerge` (committed, not yet merged)                                                       |
 | Merged         | `automerged`                                                                                                                            |
 | Limited        | `pr-limit-reached`, `branch-limit-reached`, `commit-per-run-limit-reached`, `commit-hourly-limit-reached`, `minimum-group-size-not-met` |
-| Not scheduled  | `not-scheduled`, `update-not-scheduled`                                                                                                 |
 | Error          | `error`                                                                                                                                 |
 | No work        | `no-work`; or `done` with no `prNo` and no automerge                                                                                    |
 | Unknown        | any unrecognised `result`                                                                                                               |

--- a/scripts/renovate-summary/README.md
+++ b/scripts/renovate-summary/README.md
@@ -12,8 +12,9 @@ linked back to GitHub.
 ## Features
 
 - **Action-oriented grouping** — branches are bucketed by what Renovate
-  actually did (Error, PR opened, Pending, No work, Merged),
-  ordered so the items needing the most attention come first.
+  actually did (Error, PR opened, Needs approval, Pending, Merged, Limited,
+  No work, Unknown), ordered so the items needing the most attention come
+  first.
 - **Problems table** — every problem Renovate reported (deduplicated), with
   severity level, affected branch, and message.
 - **Rich, linked tables** — repositories, PRs, branches, commit history, and

--- a/scripts/renovate-summary/renovate-summary.py
+++ b/scripts/renovate-summary/renovate-summary.py
@@ -6,7 +6,7 @@ The report is the "json" log/report output produced by Renovate. It emits:
   1. A "Problems" table listing every problem reported (top-level and per
      repository), with severity level, affected branch, and message.
   2. One described table per action category, ordered by how much attention
-     each needs (error, PR opened, pending, not scheduled, no work, merged),
+     each needs (error, PR opened, pending, no work, merged),
      grouping every branch by what Renovate did with it.
   3. A totals section.
 
@@ -115,12 +115,6 @@ ACTION_CATEGORIES = [
         "(PR/branch/commit hourly limits, or minimum group size).",
     ),
     (
-        "not-scheduled",
-        "⏰ Not scheduled",
-        "Updates skipped this run because they fell outside their configured "
-        "schedule window.",
-    ),
-    (
         "no-work",
         "💤 No work",
         "Branches that needed no action this run (already up to date, closed, "
@@ -152,8 +146,6 @@ _RESULT_TO_CATEGORY = {
     "commit-per-run-limit-reached": "limited",
     "commit-hourly-limit-reached": "limited",
     "minimum-group-size-not-met": "limited",
-    "not-scheduled": "not-scheduled",
-    "update-not-scheduled": "not-scheduled",
     "no-work": "no-work",
 }
 

--- a/scripts/renovate-summary/renovate-summary.py
+++ b/scripts/renovate-summary/renovate-summary.py
@@ -6,8 +6,8 @@ The report is the "json" log/report output produced by Renovate. It emits:
   1. A "Problems" table listing every problem reported (top-level and per
      repository), with severity level, affected branch, and message.
   2. One described table per action category, ordered by how much attention
-     each needs (error, PR opened, pending, no work, merged),
-     grouping every branch by what Renovate did with it.
+     each needs (error, PR opened, needs approval, pending, merged, limited,
+     no work, unknown), grouping every branch by what Renovate did with it.
   3. A totals section.
 
 GitHub links are derived from the repository key (assumed "owner/repo" on


### PR DESCRIPTION
## Summary

Removes the **Not scheduled** action category from the `renovate-summary`
script and its README. Renovate no longer surfaces `not-scheduled` /
`update-not-scheduled` results in the report, so this category only ever
rendered as empty.

## Changes

- Drop the `not-scheduled` entry from `ACTION_CATEGORIES`.
- Remove the `not-scheduled` / `update-not-scheduled` mappings from
  `_RESULT_TO_CATEGORY`.
- Update `README.md`: remove the category from the feature list, the section
  list (renumbering subsequent sections), and the result-to-category table.

## Notes

No behavioral change for reports that contained scheduled results, since those
result codes are no longer emitted.