### PR TITLE
fix: classify renovate closed-PR branches as blocked, not open

### DIFF
--- a/scripts/renovate-summary/README.md
+++ b/scripts/renovate-summary/README.md
@@ -12,9 +12,9 @@ linked back to GitHub.
 ## Features
 
 - **Action-oriented grouping** — branches are bucketed by what Renovate
-  actually did (Error, PR opened, Needs approval, Pending, Merged, Limited,
-  No work, Unknown), ordered so the items needing the most attention come
-  first.
+  actually did (Error, PR opened, Blocked by closed PR, Needs approval, Pending,
+  Merged, Limited, No work, Unknown), ordered so the items needing the most
+  attention come first.
 - **Problems table** — every problem Renovate reported (deduplicated), with
   severity level, affected branch, and message.
 - **Rich, linked tables** — repositories, PRs, branches, commit history, and
@@ -88,20 +88,22 @@ The generated Markdown contains the following sections, in order:
 
 1. **⚠️ Problems** — table of all reported problems.
 2. **❌ Error** — updates Renovate failed to apply.
-3. **✅ Pull request opened** — updates with a real PR (created, edited, or
-   already existing) awaiting review/merge.
-4. **🔒 Needs approval** — blocked awaiting manual approval before a PR is
+3. **✅ Pull request opened** — updates with a real, open PR (created or edited)
+   awaiting review/merge.
+4. **🚫 Blocked by closed PR** — updates Renovate will not raise again because a
+   previous PR was closed unmerged (Renovate's "PR Closed (Blocked)" state).
+5. **🔒 Needs approval** — blocked awaiting manual approval before a PR is
    created.
-5. **⏳ Pending (not created yet)** — found but no PR yet (e.g. awaiting checks,
+6. **⏳ Pending (not created yet)** — found but no PR yet (e.g. awaiting checks,
    held by `minimumReleaseAge`, or queued for branch automerge).
-6. **🚀 Merged (auto-merged, no PR)** — merged straight to the base branch via
+7. **🚀 Merged (auto-merged, no PR)** — merged straight to the base branch via
    branch automerge.
-7. **🚦 Limited (rate/limit reached)** — deferred because a Renovate limit was
+8. **🚦 Limited (rate/limit reached)** — deferred because a Renovate limit was
    reached (PR/branch/commit/group-size).
-8. **💤 No work** — nothing to do this run.
-9. **❓ Unknown** — branches whose `result` did not map to any known category,
-   listed so nothing is silently dropped.
-10. **📊 Totals** — aggregate counts.
+9. **💤 No work** — nothing to do this run.
+10. **❓ Unknown** — branches whose `result` did not map to any known category,
+    listed so nothing is silently dropped.
+11. **📊 Totals** — aggregate counts.
 
 Each action section is preceded by a one-line description of what the category
 means. Empty categories render `_None._`.
@@ -130,30 +132,39 @@ URLs in every link (abbreviated as `…` above).
 
 Renovate's report does not include explicit "created / merged / rebased" flags,
 so the script derives each branch's category from the only state signals
-available — `result`, `prBlockedBy`, and `prNo`. A present `prNo` always wins
-(an open PR, however it got there). The category keys map to Renovate's
+available — `result`, `prBlockedBy`, and `prNo`. `result` is consulted first;
+for results that do not imply a specific state, a present `prNo` is then taken
+to mean a real, open PR. The one exception is `already-existed`, Renovate's "PR
+Closed (Blocked)" state, which carries the *closed* PR's number — it is matched
+on `result` before the `prNo` fallback so a closed PR is not shown as open. The
+category keys map to Renovate's
 [`BranchResult`](https://github.com/renovatebot/renovate/blob/main/lib/workers/types.ts)
 values:
 
 <!-- markdownlint-disable MD013 -->
 
-| Category       | Condition (`result`, unless noted)                                                                                                      |
-|----------------|-----------------------------------------------------------------------------------------------------------------------------------------|
-| PR opened      | any branch with a `prNo`; or `pr-created`, `pr-edited`, `already-existed`, `rebase`                                                     |
-| Needs approval | `needs-approval`, `needs-pr-approval`                                                                                                   |
-| Pending        | `pending`; or `done` + `prBlockedBy: BranchAutomerge` (committed, not yet merged)                                                       |
-| Merged         | `automerged`                                                                                                                            |
-| Limited        | `pr-limit-reached`, `branch-limit-reached`, `commit-per-run-limit-reached`, `commit-hourly-limit-reached`, `minimum-group-size-not-met` |
-| Error          | `error`                                                                                                                                 |
-| No work        | `no-work`; or `done` with no `prNo` and no automerge                                                                                    |
-| Unknown        | any unrecognised `result`                                                                                                               |
+| Category            | Condition (`result`, unless noted)                                                                                                      |
+|---------------------|-----------------------------------------------------------------------------------------------------------------------------------------|
+| PR opened           | `pr-created`, `pr-edited`, `rebase`; or any other branch with a `prNo`                                                                  |
+| Blocked by closed PR | `already-existed` (a previous PR was closed unmerged; `prNo` points at it)                                                             |
+| Needs approval      | `needs-approval`, `needs-pr-approval`                                                                                                   |
+| Pending             | `pending`; or `done` + `prBlockedBy: BranchAutomerge` (committed, not yet merged)                                                       |
+| Merged              | `automerged`                                                                                                                            |
+| Limited             | `pr-limit-reached`, `branch-limit-reached`, `commit-per-run-limit-reached`, `commit-hourly-limit-reached`, `minimum-group-size-not-met` |
+| Error               | `error`                                                                                                                                 |
+| No work             | `no-work`; or `done` with no `prNo` and no automerge                                                                                    |
+| Unknown             | any unrecognised `result`                                                                                                               |
+
+<!-- markdownlint-enable MD013 -->
 
 <!-- markdownlint-enable MD013 -->
 
 > **Note:** This reflects *what Renovate did in this run*, not full PR history.
-> A `prNo` means a PR exists, but the report cannot tell a brand-new PR from one
-> that already existed and was rebased, and it has no "new since last run"
-> signal. For that you would need the GitHub API (`created_at` / `updated_at` /
+> A `prNo` under **PR opened** means a PR exists, but the report cannot tell a
+> brand-new PR from one that already existed and was rebased, and it has no "new
+> since last run" signal. (A `prNo` under **Blocked by closed PR** is known to be
+> closed, since `already-existed` is only emitted for a closed-unmerged PR.) For
+> richer history you would need the GitHub API (`created_at` / `updated_at` /
 > `merged_at`) or a diff of two consecutive reports.
 
 ### A note on links and `pending` branches
@@ -162,8 +173,10 @@ For `pending` updates, Renovate has not created the branch yet, so the
 `branchName` in the report is only the name it *intends* to use. Links to
 `/tree/<branch>`, `/blob/...`, and `/commits/<branch>` for those rows will
 therefore 404 until (and unless) the branch is actually pushed. Likewise,
-branches that were auto-merged and deleted will 404. A link checker run against
-the output will report these — that is expected, not a bug.
+branches that were auto-merged and deleted, or pruned after their PR was closed
+(**Blocked by closed PR**), will 404. A link checker run against the output will
+report these — that is expected, not a bug. The PR link for a **Blocked by
+closed PR** row still resolves, pointing at the closed PR.
 
 ## License
 

--- a/scripts/renovate-summary/README.md
+++ b/scripts/renovate-summary/README.md
@@ -149,19 +149,17 @@ values:
 
 <!-- markdownlint-disable MD013 -->
 
-| Category            | Condition (`result`, unless noted)                                                                                                      |
-|---------------------|-----------------------------------------------------------------------------------------------------------------------------------------|
-| PR opened           | `pr-created`, `pr-edited`, `rebase`; or `done`/an unmapped result that has a `prNo`                                                     |
-| Blocked by closed PR | `already-existed` (a previous PR was closed unmerged; `prNo` points at it)                                                             |
-| Needs approval      | `needs-approval`, `needs-pr-approval`                                                                                                   |
-| Pending             | `pending`; or `done` + `prBlockedBy: BranchAutomerge` (committed, not yet merged)                                                       |
-| Merged              | `automerged`                                                                                                                            |
-| Limited             | `pr-limit-reached`, `branch-limit-reached`, `commit-per-run-limit-reached`, `commit-hourly-limit-reached`, `minimum-group-size-not-met` |
-| Error               | `error`                                                                                                                                 |
-| No work             | `no-work`; or `done` with no `prNo` and no automerge                                                                                    |
-| Unknown             | any unrecognised `result`                                                                                                               |
-
-<!-- markdownlint-enable MD013 -->
+| Category             | Condition (`result`, unless noted)                                                                                                      |
+|----------------------|-----------------------------------------------------------------------------------------------------------------------------------------|
+| PR opened            | `pr-created`, `pr-edited`, `rebase`; or `done`/an unmapped result that has a `prNo`                                                     |
+| Blocked by closed PR | `already-existed` (a previous PR was closed unmerged; `prNo` points at it)                                                              |
+| Needs approval       | `needs-approval`, `needs-pr-approval`                                                                                                   |
+| Pending              | `pending`; or `done` + `prBlockedBy: BranchAutomerge` (committed, not yet merged)                                                       |
+| Merged               | `automerged`                                                                                                                            |
+| Limited              | `pr-limit-reached`, `branch-limit-reached`, `commit-per-run-limit-reached`, `commit-hourly-limit-reached`, `minimum-group-size-not-met` |
+| Error                | `error`                                                                                                                                 |
+| No work              | `no-work`; or `done` with no `prNo` and no automerge                                                                                    |
+| Unknown              | any unrecognised `result`                                                                                                               |
 
 <!-- markdownlint-enable MD013 -->
 

--- a/scripts/renovate-summary/README.md
+++ b/scripts/renovate-summary/README.md
@@ -88,8 +88,8 @@ The generated Markdown contains the following sections, in order:
 
 1. **⚠️ Problems** — table of all reported problems.
 2. **❌ Error** — updates Renovate failed to apply.
-3. **✅ Pull request opened** — updates with a real, open PR (created or edited)
-   awaiting review/merge.
+3. **✅ Pull request opened** — updates with a real, open PR awaiting
+   review/merge.
 4. **🚫 Blocked by closed PR** — updates Renovate will not raise again because a
    previous PR was closed unmerged (Renovate's "PR Closed (Blocked)" state).
 5. **🔒 Needs approval** — blocked awaiting manual approval before a PR is

--- a/scripts/renovate-summary/README.md
+++ b/scripts/renovate-summary/README.md
@@ -132,12 +132,18 @@ URLs in every link (abbreviated as `…` above).
 
 Renovate's report does not include explicit "created / merged / rebased" flags,
 so the script derives each branch's category from the only state signals
-available — `result`, `prBlockedBy`, and `prNo`. `result` is consulted first;
-for results that do not imply a specific state, a present `prNo` is then taken
-to mean a real, open PR. The one exception is `already-existed`, Renovate's "PR
-Closed (Blocked)" state, which carries the *closed* PR's number — it is matched
-on `result` before the `prNo` fallback so a closed PR is not shown as open. The
-category keys map to Renovate's
+available — `result`, `prBlockedBy`, and `prNo`. Any recognised `result` is
+matched first and wins, even when the branch also has a `prNo`; only a branch
+whose `result` is unmapped (or `done`) falls back to the `prNo` shortcut, where
+a present `prNo` is taken to mean a real, open PR.
+
+`result`-first ordering matters because several results carry a `prNo` while
+describing something other than an open PR awaiting review. The clearest case
+is `already-existed`, Renovate's "PR Closed (Blocked)" state, which reports the
+*closed* PR's number; matching on `result` first keeps it out of "PR opened".
+The same applies to, e.g., a rate-limited (`*-limit-reached`) or errored
+(`error`) branch that still has an open PR — it is filed under its result
+(Limited / Error) rather than "PR opened". The category keys map to Renovate's
 [`BranchResult`](https://github.com/renovatebot/renovate/blob/main/lib/workers/types.ts)
 values:
 
@@ -145,7 +151,7 @@ values:
 
 | Category            | Condition (`result`, unless noted)                                                                                                      |
 |---------------------|-----------------------------------------------------------------------------------------------------------------------------------------|
-| PR opened           | `pr-created`, `pr-edited`, `rebase`; or any other branch with a `prNo`                                                                  |
+| PR opened           | `pr-created`, `pr-edited`, `rebase`; or `done`/an unmapped result that has a `prNo`                                                     |
 | Blocked by closed PR | `already-existed` (a previous PR was closed unmerged; `prNo` points at it)                                                             |
 | Needs approval      | `needs-approval`, `needs-pr-approval`                                                                                                   |
 | Pending             | `pending`; or `done` + `prBlockedBy: BranchAutomerge` (committed, not yet merged)                                                       |

--- a/scripts/renovate-summary/renovate-summary.py
+++ b/scripts/renovate-summary/renovate-summary.py
@@ -137,12 +137,15 @@ ACTION_CATEGORIES = [
     ),
 ]
 
-# Renovate BranchResult values grouped by category key. ``already-existed`` is
-# Renovate's "PR Closed (Blocked)" state -- it is emitted only after a matching
-# PR was found closed-unmerged, and it always carries that closed PR's number
-# in ``prNo`` (see lib/workers/repository/update/branch/index.ts). It must
-# therefore be classified before the generic ``prNo`` shortcut in
-# ``classify_action`` so a closed PR is not mistaken for an open one.
+# Renovate BranchResult values grouped by category key. Any result listed here
+# is matched before the generic ``prNo`` shortcut in ``classify_action``, so a
+# recognised result wins even when the branch also carries a ``prNo``. This
+# matters for results that report a PR number while describing something other
+# than an open PR: ``already-existed`` is Renovate's "PR Closed (Blocked)"
+# state and always carries the *closed* PR's number (see
+# lib/workers/repository/update/branch/index.ts), and limit/error results can
+# likewise accompany an open PR. Those are filed by result rather than mistaken
+# for "pr".
 _RESULT_TO_CATEGORY = {
     "error": "error",
     "pr-created": "pr",
@@ -168,12 +171,15 @@ def classify_action(branch: dict[str, Any]) -> str:
     Derived from the report's ``result``, ``prBlockedBy`` and ``prNo`` fields
     -- the only state signals Renovate exposes.
 
-    ``result`` is consulted first, because some results imply a *closed* PR
-    even though they carry a ``prNo``. In particular ``already-existed`` is
-    Renovate's "PR Closed (Blocked)" state and always reports the closed PR's
-    number, so trusting ``prNo`` blindly would mis-file it as an open PR.
+    ``result`` is consulted first: any result mapped in ``_RESULT_TO_CATEGORY``
+    wins, even when the branch also carries a ``prNo``. This is because several
+    results report a PR number while describing something other than an open PR
+    awaiting review -- e.g. ``already-existed`` (Renovate's "PR Closed
+    (Blocked)" state, carrying the *closed* PR's number) or a limit/error result
+    on a branch that still has an open PR. Filing by result avoids mislabelling
+    those as open PRs.
 
-    For any other result, a present ``prNo`` means a real open PR exists
+    For an unmapped result, a present ``prNo`` means a real open PR exists
     (however it got there). The ambiguous ``done`` result is split by
     ``prBlockedBy``: ``BranchAutomerge`` means committed and queued for
     automerge (``pending``), otherwise it is treated as completed work

--- a/scripts/renovate-summary/renovate-summary.py
+++ b/scripts/renovate-summary/renovate-summary.py
@@ -87,8 +87,8 @@ ACTION_CATEGORIES = [
     (
         "pr",
         "✅ Pull request opened",
-        "Updates for which Renovate has a real, open pull request (created or "
-        "edited) -- these await your review or merge.",
+        "Updates for which Renovate has a real, open pull request -- these "
+        "await your review or merge.",
     ),
     (
         "blocked",

--- a/scripts/renovate-summary/renovate-summary.py
+++ b/scripts/renovate-summary/renovate-summary.py
@@ -6,8 +6,9 @@ The report is the "json" log/report output produced by Renovate. It emits:
   1. A "Problems" table listing every problem reported (top-level and per
      repository), with severity level, affected branch, and message.
   2. One described table per action category, ordered by how much attention
-     each needs (error, PR opened, needs approval, pending, merged, limited,
-     no work, unknown), grouping every branch by what Renovate did with it.
+     each needs (error, PR opened, blocked by closed PR, needs approval,
+     pending, merged, limited, no work, unknown), grouping every branch by what
+     Renovate did with it.
   3. A totals section.
 
 GitHub links are derived from the repository key (assumed "owner/repo" on
@@ -86,8 +87,16 @@ ACTION_CATEGORIES = [
     (
         "pr",
         "✅ Pull request opened",
-        "Updates for which Renovate has a real pull request (created, edited, "
-        "or already existing) -- these await your review or merge.",
+        "Updates for which Renovate has a real, open pull request (created or "
+        "edited) -- these await your review or merge.",
+    ),
+    (
+        "blocked",
+        "🚫 Blocked by closed PR",
+        "Updates Renovate will not raise again because a previous PR for them "
+        "was closed unmerged (Renovate's \"PR Closed (Blocked)\" state). The "
+        "linked PR is closed; rename/reopen it, or tick its box on the "
+        "Dependency Dashboard, to get a fresh PR.",
     ),
     (
         "needs-approval",
@@ -128,14 +137,17 @@ ACTION_CATEGORIES = [
     ),
 ]
 
-# Renovate BranchResult values grouped by category key. A branch with a PR
-# number is always treated as "pr" regardless of result, so results that may
-# or may not carry a PR (e.g. "already-existed") are handled by prNo first.
+# Renovate BranchResult values grouped by category key. ``already-existed`` is
+# Renovate's "PR Closed (Blocked)" state -- it is emitted only after a matching
+# PR was found closed-unmerged, and it always carries that closed PR's number
+# in ``prNo`` (see lib/workers/repository/update/branch/index.ts). It must
+# therefore be classified before the generic ``prNo`` shortcut in
+# ``classify_action`` so a closed PR is not mistaken for an open one.
 _RESULT_TO_CATEGORY = {
     "error": "error",
     "pr-created": "pr",
     "pr-edited": "pr",
-    "already-existed": "pr",
+    "already-existed": "blocked",
     "rebase": "pr",
     "needs-approval": "needs-approval",
     "needs-pr-approval": "needs-approval",
@@ -154,23 +166,30 @@ def classify_action(branch: dict[str, Any]) -> str:
     """Map a branch to one of the ACTION_CATEGORIES keys.
 
     Derived from the report's ``result``, ``prBlockedBy`` and ``prNo`` fields
-    -- the only state signals Renovate exposes. A present ``prNo`` always wins
-    (an open PR, however it got there). The ambiguous ``done`` result is split
-    by ``prBlockedBy``: ``BranchAutomerge`` means committed and queued for
+    -- the only state signals Renovate exposes.
+
+    ``result`` is consulted first, because some results imply a *closed* PR
+    even though they carry a ``prNo``. In particular ``already-existed`` is
+    Renovate's "PR Closed (Blocked)" state and always reports the closed PR's
+    number, so trusting ``prNo`` blindly would mis-file it as an open PR.
+
+    For any other result, a present ``prNo`` means a real open PR exists
+    (however it got there). The ambiguous ``done`` result is split by
+    ``prBlockedBy``: ``BranchAutomerge`` means committed and queued for
     automerge (``pending``), otherwise it is treated as completed work
     (``no-work``). Any unrecognised ``result`` falls back to ``unknown`` so the
     branch is still rendered rather than silently dropped.
     """
+    result = branch.get("result")
+    if isinstance(result, str) and result in _RESULT_TO_CATEGORY:
+        return _RESULT_TO_CATEGORY[result]
     if branch.get("prNo") is not None:
         return "pr"
-    result = branch.get("result")
     if result == "done":
         if branch.get("prBlockedBy") == "BranchAutomerge":
             return "pending"
         return "no-work"
-    if not isinstance(result, str):
-        return "unknown"
-    return _RESULT_TO_CATEGORY.get(result, "unknown")
+    return "unknown"
 
 
 def repo_url(base: str, repo: str) -> str:

--- a/scripts/renovate-summary/renovate-summary.py
+++ b/scripts/renovate-summary/renovate-summary.py
@@ -94,7 +94,7 @@ ACTION_CATEGORIES = [
         "blocked",
         "🚫 Blocked by closed PR",
         "Updates Renovate will not raise again because a previous PR for them "
-        "was closed unmerged (Renovate's \"PR Closed (Blocked)\" state). The "
+        'was closed unmerged (Renovate\'s "PR Closed (Blocked)" state). The '
         "linked PR is closed; rename/reopen it, or tick its box on the "
         "Dependency Dashboard, to get a fresh PR.",
     ),


### PR DESCRIPTION
## What

The `renovate-summary` script listed updates whose previous PR was **closed
unmerged** under **"✅ Pull request opened"**, making a closed PR look like it
was still awaiting review.

Concrete case from
[renovate-global run #27487594770](https://github.com/ruzickap/my-git-projects/actions/runs/27487594770):
the `themes/lucentlink-hugo` digest update for `ruzickap/petr.ruzicka.dev`
showed up as an open PR even though [PR #132](https://github.com/ruzickap/petr.ruzicka.dev/pull/132)
was already closed.

## Why

Such branches carry Renovate's `already-existed` result — its
["PR Closed (Blocked)"](https://github.com/renovatebot/renovate/blob/main/lib/workers/repository/update/branch/index.ts)
state — which is emitted **only** after a matching PR is found closed-unmerged
and **always reports that closed PR's number** in `prNo`. `classify_action()`
trusted `prNo` first, so it mis-filed these as open PRs.

This is a labeling fix only — Renovate and the closed PR were behaving
correctly; it will not re-raise the update.

## Changes

- Add a dedicated **🚫 Blocked by closed PR** action category.
- Map `already-existed` to it instead of `pr`.
- Consult `result` before the `prNo` fallback so a closed PR is not shown as
  open. Genuinely open PRs (`pr-created` / `pr-edited` / `rebase` / bare `prNo`)
  are unaffected.
- Update the script docstring and `README.md` accordingly.

## Verification

- 12 `classify_action` cases pass, incl. no regression for a normal open PR
  (bare `prNo` → "PR opened").
- Rendered against the real report from the run above: "Pull request opened"
  went 3 → 2, and the LucentLink update now appears under "🚫 Blocked by closed
  PR (1)", linked to closed PR #132.
- `rumdl` clean; `py_compile` clean; zero new dependencies (pure stdlib).