### PR TITLE
feat: add lock file maintenance category to renovate summary

### DIFF
--- a/scripts/renovate-summary/renovate-summary.py
+++ b/scripts/renovate-summary/renovate-summary.py
@@ -177,15 +177,19 @@ def is_lock_file_maintenance(branch: dict[str, Any]) -> bool:
     ``lockFileMaintenance`` is not a Renovate ``BranchResult``; it is flagged
     per upgrade. Renovate sets ``isLockFileMaintenance`` and
     ``updateType == "lockFileMaintenance"`` on each such upgrade and lifts
-    ``isLockFileMaintenance`` onto the branch when every upgrade is one (see
-    Renovate's updates/flatten.ts and updates/generate.ts). Either signal is
-    accepted here so the branch is recognised even on older report shapes.
+    ``isLockFileMaintenance`` onto the branch only when *every* upgrade is one
+    (see Renovate's updates/flatten.ts and updates/generate.ts). The branch
+    flag is honoured first; otherwise the branch counts as lock-file
+    maintenance only when it has upgrades and *all* of them are LFM. Requiring
+    all (not any) mirrors Renovate's own lifting rule and avoids misclassifying
+    a branch that mixes lock-file maintenance with normal dependency updates.
     """
     if branch.get("isLockFileMaintenance"):
         return True
-    return any(
+    upgrades = branch.get("upgrades") or []
+    return bool(upgrades) and all(
         u.get("isLockFileMaintenance") or u.get("updateType") == "lockFileMaintenance"
-        for u in (branch.get("upgrades") or [])
+        for u in upgrades
     )
 
 

--- a/scripts/renovate-summary/renovate-summary.py
+++ b/scripts/renovate-summary/renovate-summary.py
@@ -184,8 +184,7 @@ def is_lock_file_maintenance(branch: dict[str, Any]) -> bool:
     if branch.get("isLockFileMaintenance"):
         return True
     return any(
-        u.get("isLockFileMaintenance")
-        or u.get("updateType") == "lockFileMaintenance"
+        u.get("isLockFileMaintenance") or u.get("updateType") == "lockFileMaintenance"
         for u in (branch.get("upgrades") or [])
     )
 

--- a/scripts/renovate-summary/renovate-summary.py
+++ b/scripts/renovate-summary/renovate-summary.py
@@ -7,8 +7,8 @@ The report is the "json" log/report output produced by Renovate. It emits:
      repository), with severity level, affected branch, and message.
   2. One described table per action category, ordered by how much attention
      each needs (error, PR opened, blocked by closed PR, needs approval,
-     pending, merged, limited, no work, unknown), grouping every branch by what
-     Renovate did with it.
+     pending, merged, limited, lock file maintenance, no work, unknown),
+     grouping every branch by what Renovate did with it.
   3. A totals section.
 
 GitHub links are derived from the repository key (assumed "owner/repo" on
@@ -124,6 +124,12 @@ ACTION_CATEGORIES = [
         "(PR/branch/commit hourly limits, or minimum group size).",
     ),
     (
+        "lock-file-maintenance",
+        "🔧 Lock file maintenance",
+        "Branches refreshing lock files only (`lockFileMaintenance`), with no "
+        "dependency version change. Routine upkeep, typically auto-merged.",
+    ),
+    (
         "no-work",
         "💤 No work",
         "Branches that needed no action this run (already up to date, closed, "
@@ -165,11 +171,30 @@ _RESULT_TO_CATEGORY = {
 }
 
 
+def is_lock_file_maintenance(branch: dict[str, Any]) -> bool:
+    """Whether a branch is a lock-file-maintenance branch.
+
+    ``lockFileMaintenance`` is not a Renovate ``BranchResult``; it is flagged
+    per upgrade. Renovate sets ``isLockFileMaintenance`` and
+    ``updateType == "lockFileMaintenance"`` on each such upgrade and lifts
+    ``isLockFileMaintenance`` onto the branch when every upgrade is one (see
+    Renovate's updates/flatten.ts and updates/generate.ts). Either signal is
+    accepted here so the branch is recognised even on older report shapes.
+    """
+    if branch.get("isLockFileMaintenance"):
+        return True
+    return any(
+        u.get("isLockFileMaintenance")
+        or u.get("updateType") == "lockFileMaintenance"
+        for u in (branch.get("upgrades") or [])
+    )
+
+
 def classify_action(branch: dict[str, Any]) -> str:
     """Map a branch to one of the ACTION_CATEGORIES keys.
 
-    Derived from the report's ``result``, ``prBlockedBy`` and ``prNo`` fields
-    -- the only state signals Renovate exposes.
+    Derived from the report's ``result``, ``prBlockedBy``, ``prNo`` and
+    ``isLockFileMaintenance`` fields -- the state signals Renovate exposes.
 
     ``result`` is consulted first: any result mapped in ``_RESULT_TO_CATEGORY``
     wins, even when the branch also carries a ``prNo``. This is because several
@@ -180,17 +205,21 @@ def classify_action(branch: dict[str, Any]) -> str:
     those as open PRs.
 
     For an unmapped result, a present ``prNo`` means a real open PR exists
-    (however it got there). The ambiguous ``done`` result is split by
-    ``prBlockedBy``: ``BranchAutomerge`` means committed and queued for
-    automerge (``pending``), otherwise it is treated as completed work
-    (``no-work``). Any unrecognised ``result`` falls back to ``unknown`` so the
-    branch is still rendered rather than silently dropped.
+    (however it got there). A lock-file-maintenance branch with no PR is filed
+    under ``lock-file-maintenance`` (it carries no depName/version, so it would
+    otherwise fall into ``no-work``/``unknown``). The ambiguous ``done`` result
+    is then split by ``prBlockedBy``: ``BranchAutomerge`` means committed and
+    queued for automerge (``pending``), otherwise it is treated as completed
+    work (``no-work``). Any unrecognised ``result`` falls back to ``unknown`` so
+    the branch is still rendered rather than silently dropped.
     """
     result = branch.get("result")
     if isinstance(result, str) and result in _RESULT_TO_CATEGORY:
         return _RESULT_TO_CATEGORY[result]
     if branch.get("prNo") is not None:
         return "pr"
+    if is_lock_file_maintenance(branch):
+        return "lock-file-maintenance"
     if result == "done":
         if branch.get("prBlockedBy") == "BranchAutomerge":
             return "pending"

--- a/scripts/renovate-summary/renovate-summary.py
+++ b/scripts/renovate-summary/renovate-summary.py
@@ -204,24 +204,25 @@ def classify_action(branch: dict[str, Any]) -> str:
     those as open PRs.
 
     For an unmapped result, a present ``prNo`` means a real open PR exists
-    (however it got there). A lock-file-maintenance branch with no PR is filed
+    (however it got there). The ambiguous ``done`` result is then split by
+    ``prBlockedBy``: ``BranchAutomerge`` means committed and queued for
+    automerge (``pending``). A remaining lock-file-maintenance branch is filed
     under ``lock-file-maintenance`` (it carries no depName/version, so it would
-    otherwise fall into ``no-work``/``unknown``). The ambiguous ``done`` result
-    is then split by ``prBlockedBy``: ``BranchAutomerge`` means committed and
-    queued for automerge (``pending``), otherwise it is treated as completed
-    work (``no-work``). Any unrecognised ``result`` falls back to ``unknown`` so
-    the branch is still rendered rather than silently dropped.
+    otherwise fall into ``no-work``/``unknown``); any other ``done`` branch is
+    treated as completed work (``no-work``). Any unrecognised ``result`` falls
+    back to ``unknown`` so the branch is still rendered rather than silently
+    dropped.
     """
     result = branch.get("result")
     if isinstance(result, str) and result in _RESULT_TO_CATEGORY:
         return _RESULT_TO_CATEGORY[result]
     if branch.get("prNo") is not None:
         return "pr"
+    if result == "done" and branch.get("prBlockedBy") == "BranchAutomerge":
+        return "pending"
     if is_lock_file_maintenance(branch):
         return "lock-file-maintenance"
     if result == "done":
-        if branch.get("prBlockedBy") == "BranchAutomerge":
-            return "pending"
         return "no-work"
     return "unknown"
 


### PR DESCRIPTION
## What

Adds a dedicated **🔧 Lock file maintenance** category to the renovate-summary
report (`scripts/renovate-summary/renovate-summary.py`).

## Why

Renovate's `lockFileMaintenance` branches carry no `depName` or version and
`lockFileMaintenance` is **not** a `BranchResult` value — it is a per-upgrade
attribute. As a result these branches previously fell into `no-work` (when
`result == "done"`) or `unknown`, so lock-file refreshes were not surfaced on
their own.

## How

- Add a `lock-file-maintenance` entry to `ACTION_CATEGORIES` (placed before
  `no-work`).
- Add `is_lock_file_maintenance()`, which detects the branch-level
  `isLockFileMaintenance` flag, or — when that flag is absent — a branch whose
  upgrades are **all** lock-file maintenance (`isLockFileMaintenance` /
  `updateType == "lockFileMaintenance"`). Requiring *all* upgrades (not *any*)
  mirrors how Renovate lifts the branch flag in `updates/generate.ts` and avoids
  misclassifying a branch that mixes lock-file maintenance with normal updates.
- Classify such branches in `classify_action` **after** the result-mapped check,
  the open-PR (`prNo`) check, and the `done` + `BranchAutomerge` → `pending`
  check, so `error` / blocked / limited / `automerged` results, real open PRs,
  and branches queued for automerge still take precedence; only a terminal,
  no-PR lock-file-maintenance branch lands in the new section.
- Update the module-level and `classify_action` docstrings accordingly.

## Verification

Verified manually (no automated Python test suite exists in this repo, so no
test files are added):

- Ran `classify_action` / `is_lock_file_maintenance` against hand-built branch
  dicts covering precedence (LFM with open PR → `pr`, automerged → `automerged`,
  errored → `error`, queued automerge → `pending`, terminal →
  `lock-file-maintenance`, mixed LFM+normal → `no-work`, and non-LFM
  `no-work`/`pending` unchanged).
- Full-render smoke test confirms the new section renders with the correct
  count; the existing `upgrade_cell` fallback already labels these rows
  (`_lockFileMaintenance_ (\`package.json\`)`).
- `black`, `isort`, `python3 -m py_compile`, MegaLinter and all pre-commit hooks
  pass.

## Note

No earlier commit had actually removed `lockFileMaintenance` handling — across
all branches/tags it had only ever appeared as an example word in the
`upgrade_cell` docstring. This PR adds the category fresh rather than reverting
anything.