### PR TITLE
chore: force conventional commit PR titles in renovate

### DIFF
--- a/.github/renovate-global.json5
+++ b/.github/renovate-global.json5
@@ -172,6 +172,12 @@
   // Process repositories even without a local Renovate config file
   // https://docs.renovatebot.com/self-hosted-configuration/#requireconfig
   requireConfig: "optional",
+  // Force Conventional Commits compliant commit messages and PR titles
+  // (e.g. "chore(deps): ...", "fix(deps): ..."). Without this the default
+  // "auto" mode inspects the last 20 base-branch commits and can flip to
+  // "disabled", producing non-compliant titles like "Update dependency ...".
+  // https://docs.renovatebot.com/configuration-options/#semanticcommits
+  semanticCommits: "enabled",
   // Create separate branches for minor and patch updates
   // https://docs.renovatebot.com/configuration-options/#separateminorpatch
   separateMinorPatch: true,


### PR DESCRIPTION
## What

Set \`semanticCommits: \"enabled\"\` in \`.github/renovate-global.json5\`.

## Why

Renovate's \`semanticCommits\` option defaults to \`\"auto\"\`, which inspects
the last 20 base-branch commits to decide whether to prefix commit
messages and PR titles. In some repositories this auto-detection flips to
\`\"disabled\"\` (a known regression in recent Renovate versions, see
[renovatebot/renovate#42353](https://github.com/renovatebot/renovate/discussions/42353)),
producing PR titles that are **not** Conventional Commits compliant — e.g.
[ruzickap/brewwatch#57](https://github.com/ruzickap/brewwatch/pull/57):

> \`Update dependency esbuild to ^0.28.0 [SECURITY]\`

Forcing \`semanticCommits: \"enabled\"\` makes Renovate always emit
Conventional Commits compliant titles across **all autodiscovered repos**:

- \`chore(deps): ...\` for most updates
- \`fix(deps): ...\` for production dependencies / security updates

## Notes

- Config-only change; compatible with the existing \`commitMessageTopic\`
  override (the semantic prefix is prepended to the topic).
- No \`commitMessagePrefix\` is set, so nothing overrides semantic commits.
- Affects **future** Renovate runs only; existing open PRs are retitled on
  the next run.