### PR TITLE
chore: set renovate vulnerabilityFixStrategy to highest

### DIFF
--- a/.github/renovate-global.json5
+++ b/.github/renovate-global.json5
@@ -181,5 +181,15 @@
   // Create separate branches for minor and patch updates
   // https://docs.renovatebot.com/configuration-options/#separateminorpatch
   separateMinorPatch: true,
+  // Security (vulnerability) updates
+  // https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts
+  vulnerabilityAlerts: {
+    // Bump vulnerable deps to the newest version instead of the advisory's
+    // minimum patched floor. Without this, the default "lowest" strategy
+    // rewrites the range downward (e.g. "^8.5.15" -> "^8.5.6"), which looks
+    // like a downgrade even though it still resolves to the fixed release.
+    // https://docs.renovatebot.com/configuration-options/#vulnerabilityfixstrategy
+    vulnerabilityFixStrategy: "highest",
+  },
   // # keep-sorted end
 }


### PR DESCRIPTION
## What

Add `vulnerabilityAlerts.vulnerabilityFixStrategy: "highest"` to `.github/renovate-global.json5`.

## Why

Security (vulnerability) PRs previously rewrote the version range **down** to the advisory's minimum patched floor — e.g. [brewwatch#59](https://github.com/ruzickap/brewwatch/pull/59) showed `^8.5.15 → ^8.5.6`. That looks like a downgrade even though the caret range still resolves to the fixed release (8.5.10).

With `vulnerabilityFixStrategy: "highest"`, Renovate bumps vulnerable deps to the **newest** version instead, so the range only ever moves upward and security PRs are no longer confusing.

## Notes

- This is the global self-hosted config (no `gh-repo-defaults` copy to sync).
- Renovate is on 43.222.0, which supports `vulnerabilityFixStrategy` (added in 41.x).
- Does not retroactively change brewwatch#59; that PR can be merged as-is (safe) or closed and recreated on the next run.

Docs: <https://docs.renovatebot.com/configuration-options/#vulnerabilityfixstrategy>