### PR TITLE
feat: add RUZICKA_SBX01_AWS_ROLE_TO_ASSUME secret to ruzickap.github.io

### DIFF
--- a/opentofu/cloudflare-github/github-repositories.tf
+++ b/opentofu/cloudflare-github/github-repositories.tf
@@ -203,6 +203,8 @@ locals {
         # .github/workflows/docs-confluence-sync.yml
         "MY_ATLASSIAN_PERSONAL_TOKEN" = data.aws_ssm_parameter.github_ruzickap_ruzickap_github_io_actions_secrets_MY_ATLASSIAN_PERSONAL_TOKEN.value
         "MY_SLACK_BOT_SIGNING_SECRET" = data.aws_ssm_parameter.github_ruzickap_ruzickap_github_io_actions_secrets_MY_SLACK_BOT_SIGNING_SECRET.value
+        # Needed by .github/workflows/post_tests.yml
+        "RUZICKA_SBX01_AWS_ROLE_TO_ASSUME" = data.aws_ssm_parameter.github_shared_actions_secrets_RUZICKA_SBX01_AWS_ROLE_TO_ASSUME.value
         # keep-sorted end
       }
     }


### PR DESCRIPTION
## What

Provision the `RUZICKA_SBX01_AWS_ROLE_TO_ASSUME` GitHub Actions secret on
the `ruzickap.github.io` repository, sourced from the existing
`data.aws_ssm_parameter.github_shared_actions_secrets_RUZICKA_SBX01_AWS_ROLE_TO_ASSUME`
SSM parameter (defined in `aws.tf`).

## Why

Needed by `.github/workflows/post_tests.yml` in the `ruzickap.github.io`
repo to assume the sandbox AWS role.

## Notes

- Reuses an existing data source already consumed elsewhere in
  `github-repositories.tf` (line 157); no new data source or SSM
  parameter required.
- This is a live infrastructure change applied via the
  `opentofu/cloudflare-github` module.