### PR TITLE
feat: add MY_SLACK_BOT_TOKEN secret to ruzickap.github.io

### DIFF
--- a/opentofu/cloudflare-github/github-repositories.tf
+++ b/opentofu/cloudflare-github/github-repositories.tf
@@ -203,6 +203,7 @@ locals {
         # .github/workflows/docs-confluence-sync.yml
         "MY_ATLASSIAN_PERSONAL_TOKEN" = data.aws_ssm_parameter.github_ruzickap_ruzickap_github_io_actions_secrets_MY_ATLASSIAN_PERSONAL_TOKEN.value
         "MY_SLACK_BOT_SIGNING_SECRET" = data.aws_ssm_parameter.github_ruzickap_ruzickap_github_io_actions_secrets_MY_SLACK_BOT_SIGNING_SECRET.value
+        "MY_SLACK_BOT_TOKEN"          = data.aws_ssm_parameter.github_shared_actions_secrets_MY_SLACK_BOT_TOKEN.value
         # Needed by .github/workflows/post_tests.yml
         "RUZICKA_SBX01_AWS_ROLE_TO_ASSUME" = data.aws_ssm_parameter.github_shared_actions_secrets_RUZICKA_SBX01_AWS_ROLE_TO_ASSUME.value
         # keep-sorted end


### PR DESCRIPTION
## What

Add the `MY_SLACK_BOT_TOKEN` Actions secret to the `ruzickap/ruzickap.github.io` repository configuration in `opentofu/cloudflare-github/github-repositories.tf`.

## Why

The `ruzickap.github.io` repo's workflows need the Slack bot token alongside the existing `MY_SLACK_BOT_SIGNING_SECRET`. The value is sourced from the shared SSM parameter `data.aws_ssm_parameter.github_shared_actions_secrets_MY_SLACK_BOT_TOKEN`, which already exists in `aws.tf` and is reused for other repositories.