### PR TITLE
chore: block renovate security updates in brewwatch

### DIFF
--- a/.github/renovate-global.json5
+++ b/.github/renovate-global.json5
@@ -127,6 +127,10 @@
       matchManagers: ["mise"],
     },
     {
+      // Disables every non-github-actions manager for brewwatch so regular
+      // (non-security) updates are limited to GitHub Actions. Security fixes
+      // bypass this rule and are blocked separately via
+      // vulnerabilityAlerts.force.packageRules below.
       description: "Only update GitHub Actions in brewwatch repo",
       matchRepositories: ["ruzickap/brewwatch"],
       matchManagers: ["!github-actions"],
@@ -184,6 +188,22 @@
   // Security (vulnerability) updates
   // https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts
   vulnerabilityAlerts: {
+    // Vulnerability/security fixes "skip the line" and ignore normal
+    // packageRules (Renovate applies them via an internal force.enabled), so a
+    // plain "enabled: false" rule cannot stop them. Use force.packageRules
+    // here to also block security updates for every non-github-actions manager
+    // in brewwatch, keeping that repo limited to GitHub Actions updates only.
+    // https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts
+    force: {
+      packageRules: [
+        {
+          description: "Only update GitHub Actions in brewwatch repo (security)",
+          matchRepositories: ["ruzickap/brewwatch"],
+          matchManagers: ["!github-actions"],
+          enabled: false,
+        },
+      ],
+    },
     // Bump vulnerable deps to the newest version instead of the advisory's
     // minimum patched floor. Without this, the default "lowest" strategy
     // rewrites the range downward (e.g. "^8.5.15" -> "^8.5.6"), which looks


### PR DESCRIPTION
## What

Limit Renovate in `ruzickap/brewwatch` to **GitHub Actions updates only** — for both regular and security/vulnerability updates.

## Why

`brewwatch` already had a `packageRule` disabling every non-`github-actions` manager:

```json5
{ matchRepositories: ["ruzickap/brewwatch"], matchManagers: ["!github-actions"], enabled: false }
```

However, the `renovate-global` run still opened [brewwatch PR #59](https://github.com/ruzickap/brewwatch/pull/59) (`chore(deps): update dependency postcss to v8.5.15 [security]`).

Vulnerability/security fixes **"skip the line"** in Renovate and ignore normal `packageRules` (Renovate applies them via an internal `force.enabled`), so a plain `enabled: false` rule cannot stop them. See renovatebot/renovate [#42666](https://github.com/renovatebot/renovate/issues/42666) and [discussion #42760](https://github.com/renovatebot/renovate/discussions/42760) — the maintainer-recommended fix is `vulnerabilityAlerts.force.packageRules`.

## How

Added a `force.packageRules` block inside the existing `vulnerabilityAlerts` object (merged with `vulnerabilityFixStrategy: "highest"`) that disables every non-`github-actions` manager for `brewwatch`. Also added an explanatory comment to the original `packageRule`.

Result:

- Regular updates in `brewwatch` → GitHub Actions only (existing rule)
- Security updates in `brewwatch` → GitHub Actions only (new `force` rule)

Other repos are unaffected. Validated with the `json5` parser.