### PR TITLE
fix: unblock ghcr stability gate and show digest age in summary

### DIFF
--- a/.github/renovate-global.json5
+++ b/.github/renovate-global.json5
@@ -95,6 +95,16 @@
   },
   // Wait for releases to be at least 3 days old before creating PRs (reduces risk of buggy releases)
   minimumReleaseAge: "3 days",
+  // Proceed with updates whose datasource/registry provides no release
+  // timestamp instead of holding them back indefinitely. Renovate 42+ defaults
+  // to "timestamp-required", which treats a missing timestamp as "not yet aged"
+  // and (with internalChecksFilter=strict) never creates the branch -- this
+  // permanently blocks ghcr.io/quay.io Docker tags (e.g.
+  // ghcr.io/home-assistant/home-assistant), which expose no timestamp. Trade-off:
+  // any timestamp-less update bypasses the minimumReleaseAge cooldown for every
+  // datasource.
+  // https://docs.renovatebot.com/configuration-options/#minimumreleaseagebehaviour
+  minimumReleaseAgeBehaviour: "timestamp-optional",
   // Disable onboarding PRs since we manage config centrally in this repo
   // https://docs.renovatebot.com/self-hosted-configuration/#onboarding
   onboarding: false,

--- a/scripts/renovate-summary/README.md
+++ b/scripts/renovate-summary/README.md
@@ -22,7 +22,10 @@ linked back to GitHub.
 - **Version + age** — each upgrade shows `old → new` plus the age of the new
   version in days (e.g. `2.11.4 → 2.11.5 (4d)`), which makes
   [`minimumReleaseAge`](https://docs.renovatebot.com/configuration-options/#minimumreleaseage)
-  hold-backs obvious.
+  hold-backs obvious. Digest-only updates (container images, git submodules)
+  have no age for the *new* digest in Renovate's report, so the age of the
+  *currently pinned* version is shown instead, labelled `(cur 2d)` (e.g.
+  `1.31.1 → 1.31.1-alpine-slim (cur 2d)`) to make the distinction clear.
 - **Totals** — aggregate counts of branches, upgrades, problems, results, and
   update types.
 - **Zero dependencies** — pure Python standard library.
@@ -127,6 +130,30 @@ await your review or merge.
 
 The real output additionally includes a **Files** column and uses full GitHub
 URLs in every link (abbreviated as `…` above).
+
+### Upgrade age (`(<days>d)` vs `(cur <days>d)`)
+
+The age suffix in the **Upgrades** column comes from Renovate's dependency
+inventory (`packageFiles[].deps[]`) and has two forms:
+
+- **`(<days>d)`** — the age of the **new** version (`newVersionAgeInDays`). Shown
+  for version bumps (major/minor/patch), e.g. `v2.8.0 → v2.9.0 (0d)`. This is
+  what
+  [`minimumReleaseAge`](https://docs.renovatebot.com/configuration-options/#minimumreleaseage)
+  gates on, so a small number here explains a held-back update.
+- **`(cur <days>d)`** — the age of the **currently pinned** version
+  (`currentVersionAgeInDays`). Shown for **digest-only** updates (container
+  images, git submodules), e.g. `1.31.1 → 1.31.1-alpine-slim (cur 2d)`.
+
+Why the fallback: for a digest update the version string does not change (only
+the `@sha256:…` digest moves), and **Renovate's report carries no age or
+timestamp for the new digest at all** — only the current version's age. So
+`(cur 2d)` is the closest stability signal available without extra registry/API
+calls. Note it is *not* the age of the new digest: `minimumReleaseAge` for
+digests is evaluated against the new image's publish time, which the report does
+not expose. When no age is available for either the new or the current version
+(e.g. a floating tag like `node:lts-alpine` with no resolvable version), no
+suffix is shown.
 
 ## How branches are classified
 

--- a/scripts/renovate-summary/renovate-summary.py
+++ b/scripts/renovate-summary/renovate-summary.py
@@ -36,13 +36,30 @@ import argparse
 import json
 import sys
 from collections import Counter
-from typing import Any
+from typing import Any, NamedTuple
 from urllib.parse import quote
 
 # A parsed Renovate report's repositories, as a sorted list of (name, data).
 Repos = list[tuple[str, dict[str, Any]]]
-# Lookup of (depName, newVersion) -> newVersionAgeInDays for one repository.
-AgeIndex = dict[tuple[str, str], int]
+
+
+class AgeIndex(NamedTuple):
+    """Per-repository age lookups, sourced from the dependency inventory.
+
+    Renovate reports an upgrade's age on different fields depending on the
+    update kind, so two maps are kept:
+
+    * ``new`` -- (depName, newVersion) -> newVersionAgeInDays, the age of the
+      *target* version. Present for version bumps (major/minor/patch).
+    * ``current`` -- depName -> currentVersionAgeInDays, the age of the
+      *currently pinned* version. Used as a fallback for digest-only updates,
+      where the report carries no age or timestamp for the new digest at all
+      (only the current version's age), so it is the best stability signal
+      available.
+    """
+
+    new: dict[tuple[str, str], int]
+    current: dict[str, int]
 
 
 def tally(values: list[Any]) -> str:
@@ -267,27 +284,56 @@ def title_link(base: str, repo: str, branch: dict[str, Any]) -> str:
 
 
 def build_age_index(repo_data: dict[str, Any]) -> AgeIndex:
-    """Map (depName, newVersion) -> newVersionAgeInDays for a repo.
+    """Build per-repo age lookups (see ``AgeIndex``) from the inventory.
 
-    The age of a target version lives in the report's full dependency
-    inventory (packageFiles[].deps[].updates[]), not on the branch upgrades,
-    so it must be looked up separately.
+    The age of a dependency lives in the report's full inventory
+    (packageFiles[].deps[]), not on the branch upgrades, so it must be looked
+    up separately: ``currentVersionAgeInDays`` per dep populates the
+    ``current`` map, and each update's ``newVersionAgeInDays`` populates the
+    ``new`` map (keyed by the target version).
     """
-    index: AgeIndex = {}
+    new_index: dict[tuple[str, str], int] = {}
+    current_index: dict[str, int] = {}
     for managers in (repo_data.get("packageFiles") or {}).values():
         for package_file in managers or []:
             for dep in package_file.get("deps") or []:
                 name = dep.get("depName") or dep.get("packageName")
                 if name is None:
                     continue
+                current_age = dep.get("currentVersionAgeInDays")
+                if current_age is not None:
+                    current_index.setdefault(name, current_age)
                 for update in dep.get("updates") or []:
                     age = update.get("newVersionAgeInDays")
                     if age is None:
                         continue
                     value = update.get("newVersion") or update.get("newValue")
                     if value is not None:
-                        index.setdefault((name, value), age)
-    return index
+                        new_index.setdefault((name, value), age)
+    return AgeIndex(new=new_index, current=current_index)
+
+
+def age_cell(upgrade: dict[str, Any], age_index: AgeIndex) -> str:
+    """Return the age suffix for an upgrade, e.g. " (4d)" or " (cur 2d)".
+
+    Returns an empty string when no age is known. The new-version age (age of
+    the *target* version) is preferred and rendered as ``(4d)``. When that is
+    absent -- which is always the case for digest-only updates, since Renovate
+    reports no age or timestamp for the new digest -- the age of the
+    *currently pinned* version is used instead and rendered as ``(cur 2d)`` to
+    signal it is the current version's age rather than the new artifact's.
+    """
+    name = upgrade.get("depName") or upgrade.get("packageName")
+    if name is None:
+        return ""
+    new_value = upgrade.get("newVersion") or upgrade.get("newValue")
+    new_age = age_index.new.get((name, new_value)) if new_value else None
+    if new_age is not None:
+        return f" ({new_age}d)"
+    current_age = age_index.current.get(name)
+    if current_age is not None:
+        return f" (cur {current_age}d)"
+    return ""
 
 
 def upgrade_cell(upgrade: dict[str, Any], age_index: AgeIndex) -> str:
@@ -296,6 +342,18 @@ def upgrade_cell(upgrade: dict[str, Any], age_index: AgeIndex) -> str:
     Appends the age of the new version (e.g. "(0d)") when known. Falls back to
     digests, then to the dependency name / update type when no version
     information is available (e.g. lockFileMaintenance).
+
+    Age handling has two sources, because Renovate reports it differently per
+    update kind:
+
+    * Version bumps carry ``newVersionAgeInDays`` (age of the *target*
+      version), rendered as e.g. ``(4d)``.
+    * Digest-only updates (container images, git submodules) carry no age or
+      timestamp for the *new* digest at all. As a fallback, the age of the
+      *currently pinned* version (``currentVersionAgeInDays``) is shown,
+      labelled ``(cur 2d)`` to make clear it is the current version's age --
+      how long the pinned tag has existed -- not the age of the new digest.
+      This is the closest stability signal the report exposes for digests.
     """
     name = upgrade.get("depName") or upgrade.get("packageName")
     from_ver = (
@@ -309,10 +367,7 @@ def upgrade_cell(upgrade: dict[str, Any], age_index: AgeIndex) -> str:
         or short(upgrade.get("newDigest"))
     )
 
-    # Age of the new version, looked up from the dependency inventory.
-    new_value = upgrade.get("newVersion") or upgrade.get("newValue")
-    age = age_index.get((name, new_value)) if name is not None and new_value else None
-    age_suffix = f" ({age}d)" if age is not None else ""
+    age_suffix = age_cell(upgrade, age_index)
 
     if from_ver is not None and to_ver is not None:
         return f"`{from_ver}` → `{to_ver}`{age_suffix}"
@@ -487,8 +542,9 @@ def render_totals(data: dict[str, Any], repos: Repos) -> list[str]:
 def build_report(data: dict[str, Any], base: str) -> str:
     """Build the full Markdown report from a parsed Renovate JSON report."""
     repos: Repos = sorted((data.get("repositories") or {}).items())
-    # Per-repo lookup of new-version age, sourced from the dependency
-    # inventory (packageFiles), keyed by (depName, newVersion).
+    # Per-repo age lookups, sourced from the dependency inventory
+    # (packageFiles): new-version age keyed by (depName, newVersion), plus
+    # current-version age keyed by depName for digest-update fallbacks.
     age_indexes = {repo: build_age_index(r) for repo, r in repos}
 
     lines: list[str] = []

--- a/scripts/renovate-summary/renovate-summary.py
+++ b/scripts/renovate-summary/renovate-summary.py
@@ -51,15 +51,17 @@ class AgeIndex(NamedTuple):
 
     * ``new`` -- (depName, newVersion) -> newVersionAgeInDays, the age of the
       *target* version. Present for version bumps (major/minor/patch).
-    * ``current`` -- depName -> currentVersionAgeInDays, the age of the
-      *currently pinned* version. Used as a fallback for digest-only updates,
-      where the report carries no age or timestamp for the new digest at all
-      (only the current version's age), so it is the best stability signal
-      available.
+    * ``current`` -- (depName, currentVersion) -> currentVersionAgeInDays, the
+      age of the *currently pinned* version. Used as a fallback for digest-only
+      updates, where the report carries no age or timestamp for the new digest
+      at all (only the current version's age), so it is the best stability
+      signal available. It is keyed by version too (not just name) so that the
+      same dependency pinned to different versions across files does not
+      collapse to a single, order-dependent age.
     """
 
     new: dict[tuple[str, str], int]
-    current: dict[str, int]
+    current: dict[tuple[str, str], int]
 
 
 def tally(values: list[Any]) -> str:
@@ -289,11 +291,12 @@ def build_age_index(repo_data: dict[str, Any]) -> AgeIndex:
     The age of a dependency lives in the report's full inventory
     (packageFiles[].deps[]), not on the branch upgrades, so it must be looked
     up separately: ``currentVersionAgeInDays`` per dep populates the
-    ``current`` map, and each update's ``newVersionAgeInDays`` populates the
-    ``new`` map (keyed by the target version).
+    ``current`` map (keyed by the current version), and each update's
+    ``newVersionAgeInDays`` populates the ``new`` map (keyed by the target
+    version).
     """
     new_index: dict[tuple[str, str], int] = {}
-    current_index: dict[str, int] = {}
+    current_index: dict[tuple[str, str], int] = {}
     for managers in (repo_data.get("packageFiles") or {}).values():
         for package_file in managers or []:
             for dep in package_file.get("deps") or []:
@@ -301,8 +304,9 @@ def build_age_index(repo_data: dict[str, Any]) -> AgeIndex:
                 if name is None:
                     continue
                 current_age = dep.get("currentVersionAgeInDays")
-                if current_age is not None:
-                    current_index.setdefault(name, current_age)
+                current_value = dep.get("currentVersion") or dep.get("currentValue")
+                if current_age is not None and current_value is not None:
+                    current_index.setdefault((name, current_value), current_age)
                 for update in dep.get("updates") or []:
                     age = update.get("newVersionAgeInDays")
                     if age is None:
@@ -330,7 +334,10 @@ def age_cell(upgrade: dict[str, Any], age_index: AgeIndex) -> str:
     new_age = age_index.new.get((name, new_value)) if new_value else None
     if new_age is not None:
         return f" ({new_age}d)"
-    current_age = age_index.current.get(name)
+    current_value = upgrade.get("currentVersion") or upgrade.get("currentValue")
+    current_age = (
+        age_index.current.get((name, current_value)) if current_value else None
+    )
     if current_age is not None:
         return f" (cur {current_age}d)"
     return ""


### PR DESCRIPTION
## What

Two related changes prompted by GHCR Docker updates being silently stuck.

### 1. Unblock GHCR/Quay updates held by the stability gate

`.github/renovate-global.json5`: set `minimumReleaseAgeBehaviour: "timestamp-optional"`.

Renovate 42+ defaults to `timestamp-required`, which treats any update
**lacking a release timestamp** as if it is *not yet* past
`minimumReleaseAge`. Combined with the default `internalChecksFilter=strict`,
Renovate then **does not even create the branch**
(`creation is disabled because internalChecksFilter was not met`).

`ghcr.io` / `quay.io` Docker tags expose **no** release timestamp Renovate can
read ([renovate docs](https://docs.renovatebot.com/key-concepts/minimum-release-age/#which-registries-support-release-timestamps), tracking [#39064](https://github.com/renovatebot/renovate/issues/39064)),
so updates such as `ghcr.io/home-assistant/home-assistant`,
`ghcr.io/esphome/esphome`, `ghcr.io/gethomepage/homepage` and
`ghcr.io/koenkk/zigbee2mqtt` were stuck indefinitely.

`timestamp-optional` restores the pre-v42 behaviour: a timestamp-less update is
treated as already aged and is proposed/automerged.

> [!WARNING]
> **Trade-off:** this is global. Any update whose datasource/registry provides
> no timestamp now **bypasses the 3-day `minimumReleaseAge` cooldown for every
> datasource**, not just GHCR. With `automerge: true` + `automergeType: branch`,
> such updates merge straight to `main` with no cooldown. A narrower
> alternative (`packageRules` with `minimumReleaseAge: null` matching
> `ghcr.io/**`) was considered; the global flag was chosen deliberately.

### 2. Show an age for digest-only updates in the summary

`scripts/renovate-summary/renovate-summary.py`: the **Upgrades** column
previously showed an age only for version bumps (`newVersionAgeInDays`).
Digest-only updates (container images, git submodules) carry no age for the new
digest in the report, so they showed nothing. They now fall back to the
**current** version's age (`currentVersionAgeInDays`), labelled `(cur 2d)` to
distinguish it from the new-version age `(0d)`.

Example: `1.31.1 → 1.31.1-alpine-slim (cur 2d)`. When no age exists for either
(e.g. a floating tag like `node:lts-alpine`), no suffix is shown.

## Verification

- `renovate-config-validator` (pinned to the in-use Renovate `43.227.1`):
  `Config validated successfully`.
- `renovate-summary.py`: byte-compiles, `black --check` clean, all lines ≤ 88
  cols, README passes `rumdl`, output verified against a real `renovate-report.json`
  (nginx/ruby/alpine digests show `(cur Nd)`, github-actions still shows `(0d)`).
- All pre-commit hooks pass (codespell, commitizen, gitlint, keep-sorted, ...).

## Notes

- `minimumReleaseAgeBehaviour` is placed right after `minimumReleaseAge` to keep
  the `keep-sorted` block alphabetical.
- Does **not** touch `gh-repo-defaults/` — `renovate-global.json5` is specific to
  this repo's workflow and is not a distributed default.