### PR TITLE
ci: skip commit-check for my-renovate[bot]

### DIFF
--- a/.github/workflows/commit-check.yml
+++ b/.github/workflows/commit-check.yml
@@ -27,5 +27,5 @@ jobs:
           CCHK_SUBJECT_CAPITALIZED: false
           CCHK_SUBJECT_MAX_LENGTH: 72
           # Skip branch-name checks for automation bots. Ex. dependabot hardcodes the `dependabot/<ecosystem>/...` branch prefix and cannot satisfy Conventional Branch
-          CCHK_IGNORE_AUTHORS: "copilot[bot],dependabot[bot],github-actions[bot]"
-          CCHK_BRANCH_IGNORE_AUTHORS: "copilot[bot],dependabot[bot],github-actions[bot]"
+          CCHK_IGNORE_AUTHORS: "copilot[bot],dependabot[bot],github-actions[bot],my-renovate[bot]"
+          CCHK_BRANCH_IGNORE_AUTHORS: "copilot[bot],dependabot[bot],github-actions[bot],my-renovate[bot]"

--- a/gh-repo-defaults/my-defaults/.github/workflows/commit-check.yml
+++ b/gh-repo-defaults/my-defaults/.github/workflows/commit-check.yml
@@ -27,5 +27,5 @@ jobs:
           CCHK_SUBJECT_CAPITALIZED: false
           CCHK_SUBJECT_MAX_LENGTH: 72
           # Skip branch-name checks for automation bots. Ex. dependabot hardcodes the `dependabot/<ecosystem>/...` branch prefix and cannot satisfy Conventional Branch
-          CCHK_IGNORE_AUTHORS: "copilot[bot],dependabot[bot],github-actions[bot]"
-          CCHK_BRANCH_IGNORE_AUTHORS: "copilot[bot],dependabot[bot],github-actions[bot]"
+          CCHK_IGNORE_AUTHORS: "copilot[bot],dependabot[bot],github-actions[bot],my-renovate[bot]"
+          CCHK_BRANCH_IGNORE_AUTHORS: "copilot[bot],dependabot[bot],github-actions[bot],my-renovate[bot]"


### PR DESCRIPTION
## What

Add `my-renovate[bot]` to `CCHK_IGNORE_AUTHORS` and `CCHK_BRANCH_IGNORE_AUTHORS` in both `commit-check.yml` files:

- `.github/workflows/commit-check.yml` (root copy)
- `gh-repo-defaults/my-defaults/.github/workflows/commit-check.yml` (template distributed to downstream repos)

## Why

Renovate opens PRs from branches like `chore/renovate/<package>-<version>` that cannot satisfy the Conventional Branch check, so commit-check fails. This adds the same exclusion already in place for `dependabot[bot]`.

Example of the failing check: ruzickap/cheatsheet-atom#103

Both copies are updated together to keep the root config and the `gh-repo-defaults` template in sync. The downstream template change takes effect in the other repos on the next multi-gitter run.