### PR TITLE
fix: set renovate internalChecksFilter to strict

### DIFF
--- a/.github/renovate-global.json5
+++ b/.github/renovate-global.json5
@@ -79,6 +79,17 @@
     ":enableVulnerabilityAlertsWithLabel(security)", // Add security label to vulnerability alerts
     ":pinSkipCi", // Pin dependencies and skip CI for pin-only updates
   ],
+  // Use internal checks only and do NOT publish a "renovate/stability-days"
+  // commit status. With automergeType=branch, Renovate POSTs that status to
+  // GitHub before merging; the GitHub App receives a 422 that Renovate's error
+  // handler mis-parses (err.body.errors is not an array), throwing
+  // REPOSITORY_CHANGED and aborting every repo *before* automerge -- so no
+  // branch ever merges. "strict" makes Renovate evaluate minimumReleaseAge
+  // internally and skip the status POST entirely, unblocking automerge.
+  // Requires minimumReleaseAgeBehaviour=timestamp-optional (set above) so
+  // timestamp-less ghcr.io tags are not held back forever under strict.
+  // https://docs.renovatebot.com/configuration-options/#internalchecksfilter
+  internalChecksFilter: "strict",
   // Scan Kubernetes manifests in deploy directory (for malware-cryptominer-container)
   kubernetes: {
     managerFilePatterns: ["/^deploy/.+\\.ya?ml$/"],
@@ -98,8 +109,8 @@
   // Proceed with updates whose datasource/registry provides no release
   // timestamp instead of holding them back indefinitely. Renovate 42+ defaults
   // to "timestamp-required", which treats a missing timestamp as "not yet aged"
-  // and (with internalChecksFilter=strict) never creates the branch -- this
-  // permanently blocks ghcr.io/quay.io Docker tags (e.g.
+  // and (because internalChecksFilter=strict is set above) never creates the
+  // branch -- this permanently blocks ghcr.io/quay.io Docker tags (e.g.
   // ghcr.io/home-assistant/home-assistant), which expose no timestamp. Trade-off:
   // any timestamp-less update bypasses the minimumReleaseAge cooldown for every
   // datasource.

--- a/.github/renovate-global.json5
+++ b/.github/renovate-global.json5
@@ -86,7 +86,7 @@
   // REPOSITORY_CHANGED and aborting every repo *before* automerge -- so no
   // branch ever merges. "strict" makes Renovate evaluate minimumReleaseAge
   // internally and skip the status POST entirely, unblocking automerge.
-  // Requires minimumReleaseAgeBehaviour=timestamp-optional (set above) so
+  // Requires minimumReleaseAgeBehaviour=timestamp-optional (set below) so
   // timestamp-less ghcr.io tags are not held back forever under strict.
   // https://docs.renovatebot.com/configuration-options/#internalchecksfilter
   internalChecksFilter: "strict",


### PR DESCRIPTION
## Problem

`renovate-global` runs completed but **no `chore/renovate/*` branches ever merged**. Every repository aborted at the same point: Renovate POSTs the `renovate/stability-days` commit status (required by `minimumReleaseAge` + `automergeType: branch`), GitHub returns **422** for the My Renovate GitHub App, and Renovate's 422 handler crashes:

```
TypeError: err.body?.errors?.find is not a function
  at handleGotError (lib/util/http/github.ts:183:34)
  at setBranchStatus (lib/modules/platform/github/index.ts:1320)
  at setStability (lib/workers/repository/update/branch/status-checks.ts:109)
```

The crash throws `REPOSITORY_CHANGED` and aborts the repo **before** the automerge step, so the GitHub App never gets to fast-forward the branch into `main` (even though it has ruleset bypass).

## Evidence

Across two runs ([27859610869](https://github.com/ruzickap/my-git-projects/actions/runs/27859610869), [27860648802](https://github.com/ruzickap/my-git-projects/actions/runs/27860648802)) **24/24 repos** failed identically. The **only** repo that merged was `action-my-markdown-link-checker` — the one where the `renovate/stability-days` status had been manually pre-set to green, so Renovate's `setBranchStatus` short-circuited and skipped the failing POST. That isolates the status POST as the sole blocker.

## Fix

Set `internalChecksFilter: "strict"`. With `strict`, Renovate evaluates `minimumReleaseAge` **internally** and does **not** publish the `renovate/stability-days` commit status — removing the failing `POST /statuses` call entirely, so automerge proceeds.

Relies on the existing `minimumReleaseAgeBehaviour: "timestamp-optional"` so timestamp-less `ghcr.io` tags (home-assistant, esphome, zigbee2mqtt) are not blocked forever under `strict`.

## Notes / follow-up

- This sidesteps the symptom. The underlying Renovate defect (a non-array 422 `errors` body crashing `github.ts:183` and aborting the whole repo) is worth reporting upstream separately. The true GitHub 422 reason stays masked by that parser bug — direct `POST /statuses` as the same App (single, org-wide token, exact SHA, and a 20-request burst) all return `201`, so it could not be reproduced outside the Renovate runtime.
- Validated with `renovate-config-validator`: `internalChecksFilter` accepted, no parse errors (pre-existing global-vs-repo schema warnings are unchanged).