### PR TITLE
fix: disable renovate/stability-days status to unblock automerge

### DIFF
--- a/.github/renovate-global.json5
+++ b/.github/renovate-global.json5
@@ -206,6 +206,19 @@
   // Create separate branches for minor and patch updates
   // https://docs.renovatebot.com/configuration-options/#separateminorpatch
   separateMinorPatch: true,
+  // Disable the "renovate/stability-days" (minimumReleaseAge) commit status.
+  // With automergeType=branch, Renovate POSTs this status to the branch HEAD
+  // before merging; the GitHub App's POST gets a 422 that Renovate's error
+  // handler mis-parses (github.ts:183, err.body.errors is not an array),
+  // throwing REPOSITORY_CHANGED and aborting the repo *before* automerge -- so
+  // no branch merges. internalChecksFilter=strict only gates branch creation;
+  // it does NOT stop this status POST. Setting the status name to null skips
+  // the POST entirely (minimumReleaseAge is still enforced internally), letting
+  // the App fast-forward chore/renovate/* into main.
+  // https://docs.renovatebot.com/configuration-options/#statuschecknames
+  statusCheckNames: {
+    minimumReleaseAge: null,
+  },
   // Security (vulnerability) updates
   // https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts
   vulnerabilityAlerts: {


### PR DESCRIPTION
## Why the previous fix didn't work

PR #376 set `internalChecksFilter: "strict"`, but run [27861225854](https://github.com/ruzickap/my-git-projects/actions/runs/27861225854) still showed **23 status-POST 422s** and the same crash. Only `xvx.cz` merged — and only because its `renovate/stability-days` status had been manually set green earlier, so Renovate skipped the POST (`Status check renovate/stability-days is already up-to-date` → `Branch automerged`).

Root cause of the miss: `internalChecksFilter: strict` only controls **whether branches are created** for not-yet-aged deps. It does **not** stop Renovate from publishing the `renovate/stability-days` commit status — which is the POST that 422s and crashes the repo (`github.ts:183`, non-array `err.body.errors`) before automerge.

## The actual fix

Per maintainer guidance ([renovatebot/renovate#28283](https://github.com/renovatebot/renovate/discussions/28283)) and the [`statusCheckNames` docs](https://docs.renovatebot.com/configuration-options/#statuschecknames) ("Setting the value to `null` … disables or skips that status check"):

```json5
statusCheckNames: {
  minimumReleaseAge: null,
}
```

`renovate/stability-days` is the default name for the `minimumReleaseAge` status. Setting it to `null` skips the status POST entirely, so the failing request never happens and the GitHub App can fast-forward `chore/renovate/*` into `main`. `minimumReleaseAge` is still enforced internally (via `internalChecksFilter`), so the 3-day cooldown behavior is unchanged.

`internalChecksFilter: "strict"` (from #376) is **kept** — it's the recommended companion to `minimumReleaseAge` and correctly gates branch creation.

## Validation

- `renovate-config-validator`: `statusCheckNames` accepted, no parse errors.
- keep-sorted / prettier / commit hooks pass.

## Follow-up (unchanged)

The underlying Renovate defect — a non-array 422 `errors` body crashing `github.ts:183` and aborting the whole repo — still warrants an upstream bug report. This change avoids triggering it.