### PR TITLE
fix: ignore ansible comparisons:image:strict false positive

### DIFF
--- a/.github/renovate-global.json5
+++ b/.github/renovate-global.json5
@@ -174,6 +174,17 @@
       pinDigests: false,
     },
     {
+      // Renovate's ansible manager treats every "image:" key as a Docker image,
+      // including "comparisons: { image: strict }" -- a community.docker
+      // docker_container module option (strict/ignore/allow_more_present), not
+      // an image. That phantom dep makes Renovate probe docker.io/library/strict
+      // and log a harmless 401. Ignore it. (ansible-raspberry-pi-os apps.yml)
+      description: "Ignore ansible docker_container comparisons:image:strict false positive",
+      matchDatasources: ["docker"],
+      matchPackageNames: ["strict", "library/strict"],
+      enabled: false,
+    },
+    {
       description: "Skip renovating _posts directory in ruzickap.github.io",
       matchRepositories: ["ruzickap/ruzickap.github.io"],
       matchFileNames: ["_posts/**"],

--- a/.github/renovate-global.json5
+++ b/.github/renovate-global.json5
@@ -178,8 +178,12 @@
       // including "comparisons: { image: strict }" -- a community.docker
       // docker_container module option (strict/ignore/allow_more_present), not
       // an image. That phantom dep makes Renovate probe docker.io/library/strict
-      // and log a harmless 401. Ignore it. (ansible-raspberry-pi-os apps.yml)
+      // and log a harmless 401. Scope the ignore to the ansible manager in the
+      // affected repo so a genuine Docker image named "strict" elsewhere is not
+      // suppressed. (ansible-raspberry-pi-os apps.yml)
       description: "Ignore ansible docker_container comparisons:image:strict false positive",
+      matchRepositories: ["ruzickap/ansible-raspberry-pi-os"],
+      matchManagers: ["ansible"],
       matchDatasources: ["docker"],
       matchPackageNames: ["strict", "library/strict"],
       enabled: false,


### PR DESCRIPTION
## Problem

In the last `renovate-global` run, `ansible-raspberry-pi-os` logged 8× `HEAD https://index.docker.io/v2/library/strict/manifests/latest = 401`.

**Root cause:** Renovate's `ansible` manager treats every `image:` key as a Docker image. In `ansible/tasks/apps.yml` (4 containers: zigbee2mqtt, esphome, home-assistant, homepage) there is:

```yaml
community.docker.docker_container:
  image: ghcr.io/...:tag@sha256:...   # the real image
  comparisons:
    image: strict                      # ← module option, NOT an image
```

`comparisons.image: strict` is a `community.docker.docker_container` comparison mode (`strict`/`ignore`/`allow_more_present`). Renovate extracts `strict` as a phantom Docker dep, probes `docker.io/library/strict`, and logs a harmless 401.

## Fix

Add a `packageRules` entry disabling the docker dep named `strict` / `library/strict`. Central (no edits to the downstream repo), removes the noise for all 4 occurrences.

## Validation

`renovate-config-validator`: rule accepted; error count identical to `main` (only the pre-existing global-vs-repo schema false flags remain).

## Notes

Purely log-noise cleanup — nothing was blocked by this. Found while auditing run [27861888615](https://github.com/ruzickap/my-git-projects/actions/runs/27861888615).