### PR TITLE
chore: simplify renovate log env, drop custom env-regex

### DIFF
--- a/.github/workflows/renovate-global.yml
+++ b/.github/workflows/renovate-global.yml
@@ -50,10 +50,9 @@ jobs:
         with:
           configurationFile: .github/renovate-global.json5
           token: ${{ steps.app-token.outputs.token }}
-          env-regex: "^(?:RENOVATE_\\w+|LOG_\\w+|GITHUB_COM_TOKEN|NODE_OPTIONS|(?:HTTPS?|NO)_PROXY|(?:https?|no)_proxy)$"
         env:
           # Write Renovate logs to a file - https://docs.renovatebot.com/config-overview/#logging-variables
-          LOG_FILE: /tmp/renovate-log.json
+          RENOVATE_LOG_FILE: /tmp/renovate-log.json
           # Write a Renovate report to a file - https://docs.renovatebot.com/self-hosted-configuration/#reporttype
           RENOVATE_REPORT_TYPE: file
           RENOVATE_REPORT_PATH: /tmp/renovate-report.json


### PR DESCRIPTION
## Change

Simplify the Renovate logging env in `.github/workflows/renovate-global.yml`:

```diff
-          env-regex: "^(?:RENOVATE_\\w+|LOG_\\w+|GITHUB_COM_TOKEN|NODE_OPTIONS|(?:HTTPS?|NO)_PROXY|(?:https?|no)_proxy)$"
         env:
-          LOG_FILE: /tmp/renovate-log.json
+          RENOVATE_LOG_FILE: /tmp/renovate-log.json
```

## Why

- `RENOVATE_LOG_FILE` is the `RENOVATE_`-prefixed form of the log-file env var, so it matches the `renovatebot/github-action` **default** env allowlist.
- The custom `env-regex` existed only to pass the non-prefixed `LOG_*` var through to the Renovate container. With the rename it's redundant, so it's removed.

Net: same behavior (Renovate still writes its log to `/tmp/renovate-log.json`), less config.

## Validation

`actionlint` clean.