### PR TITLE
chore: update dependencies and repo defaults

### DIFF
--- a/.github/workflows/aws-cloudformation-gh-action.yml
+++ b/.github/workflows/aws-cloudformation-gh-action.yml
@@ -16,7 +16,7 @@ jobs:
       contents: read
     steps:
       - name: Check out repository code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/mega-linter-repos.yml
+++ b/.github/workflows/mega-linter-repos.yml
@@ -115,7 +115,7 @@ jobs:
           permission-contents: read
 
       - name: Checkout ${{ matrix.repo }}
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: ${{ env.REPO_OWNER }}/${{ matrix.repo }}
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/pre-commit-config.yml
+++ b/.github/workflows/pre-commit-config.yml
@@ -30,7 +30,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/renovate-global.yml
+++ b/.github/workflows/renovate-global.yml
@@ -25,7 +25,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/tofu-aws-tests.yml
+++ b/.github/workflows/tofu-aws-tests.yml
@@ -25,7 +25,7 @@ jobs:
     permissions:
       contents: read # Required to checkout repository.
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/tofu-cloudflare-github.yml
+++ b/.github/workflows/tofu-cloudflare-github.yml
@@ -45,7 +45,7 @@ jobs:
       issues: write # Required to open issue on drift.
       pull-requests: write # Required to add PR comment.
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
       - id: shellcheck
 
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.105.0
+    rev: v1.107.0
     hooks:
       - id: terraform_checkov
         # args:
@@ -60,7 +60,7 @@ repos:
           - --args=--version "~> 1.11"
 
   - repo: https://github.com/rvben/rumdl-pre-commit
-    rev: v0.1.93
+    rev: v0.2.20
     hooks:
       - id: rumdl-fmt
 
@@ -122,12 +122,12 @@ repos:
           )$
 
   - repo: https://github.com/google/keep-sorted
-    rev: v0.8.0
+    rev: v0.9.0
     hooks:
       - id: keep-sorted
 
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: v4.16.2
+    rev: v4.16.3
     hooks:
       - id: commitizen
         stages: [commit-msg]
@@ -135,7 +135,7 @@ repos:
         stages: [pre-push]
 
   - repo: https://github.com/commit-check/commit-check
-    rev: v2.7.0
+    rev: v2.8.0
     hooks:
       - id: check-message
       - id: check-branch

--- a/gh-repo-defaults/action/.github/workflows/docker-image.yml
+++ b/gh-repo-defaults/action/.github/workflows/docker-image.yml
@@ -32,7 +32,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm]
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/gh-repo-defaults/action/.github/workflows/readme-commands-check.yml
+++ b/gh-repo-defaults/action/.github/workflows/readme-commands-check.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm]
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/gh-repo-defaults/action/.github/workflows/release-please.yml
+++ b/gh-repo-defaults/action/.github/workflows/release-please.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Checkout repository
         if: ${{ steps.release.outputs.release_created }}
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/gh-repo-defaults/ansible/.mega-linter.yml
+++ b/gh-repo-defaults/ansible/.mega-linter.yml
@@ -69,6 +69,9 @@ REPOSITORY_CHECKOV_ARGUMENTS: --quiet
 #   - DS137138: "Insecure URL" (for HTTP links that are intentional)
 REPOSITORY_DEVSKIM_ARGUMENTS: --ignore-globs CHANGELOG.md --ignore-rule-ids DS162092,DS137138
 
+# Kingfisher (secret scanner) - exclude .git directory to avoid false positives on Git metadata files (e.g., refs that match token patterns)
+REPOSITORY_KINGFISHER_ARGUMENTS: --exclude .git
+
 # Trivy (vulnerability scanner) - only check HIGH and CRITICAL severity
 REPOSITORY_TRIVY_ARGUMENTS: --severity HIGH,CRITICAL --ignore-unfixed
 

--- a/gh-repo-defaults/hugo/.github/workflows/gh-pages-build.yml
+++ b/gh-repo-defaults/hugo/.github/workflows/gh-pages-build.yml
@@ -34,7 +34,7 @@ jobs:
       contents: write
       deployments: write
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           submodules: true

--- a/gh-repo-defaults/hugo/.github/workflows/links.yml
+++ b/gh-repo-defaults/hugo/.github/workflows/links.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/gh-repo-defaults/latex/.devcontainer/devcontainer.json
+++ b/gh-repo-defaults/latex/.devcontainer/devcontainer.json
@@ -55,7 +55,7 @@
 
   "features": {
     // https://github.com/devcontainers/features/tree/main/src/docker-in-docker
-    "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+    "ghcr.io/devcontainers/features/docker-in-docker:3": {}
   },
 
   "hostRequirements": {

--- a/gh-repo-defaults/latex/.github/workflows/latex-build.yml
+++ b/gh-repo-defaults/latex/.github/workflows/latex-build.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout Code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/gh-repo-defaults/latex/.github/workflows/release-please.yml
+++ b/gh-repo-defaults/latex/.github/workflows/release-please.yml
@@ -38,7 +38,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout Code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           submodules: true

--- a/gh-repo-defaults/my-defaults/.github/workflows/codeql.yml
+++ b/gh-repo-defaults/my-defaults/.github/workflows/codeql.yml
@@ -26,7 +26,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/gh-repo-defaults/my-defaults/.github/workflows/commit-check.yml
+++ b/gh-repo-defaults/my-defaults/.github/workflows/commit-check.yml
@@ -17,12 +17,12 @@ jobs:
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: commit-check/commit-check-action@c7245f6139b55db23f92266c2f0ff8429c64de80 # v2.8.0
+      - uses: commit-check/commit-check-action@60e903b3fb06f5e64580b959f58d5b9406a3e002 # v2.9.0
         env:
           CCHK_SUBJECT_CAPITALIZED: false
           CCHK_SUBJECT_MAX_LENGTH: 72

--- a/gh-repo-defaults/my-defaults/.github/workflows/mega-linter.yml
+++ b/gh-repo-defaults/my-defaults/.github/workflows/mega-linter.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout Code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 2
           persist-credentials: false

--- a/gh-repo-defaults/my-defaults/.github/workflows/pr-slack-notification.yml
+++ b/gh-repo-defaults/my-defaults/.github/workflows/pr-slack-notification.yml
@@ -64,7 +64,7 @@ jobs:
     if: ${{ startsWith(github.event.pull_request.html_url, 'https') || startsWith(github.event.issue.pull_request.html_url, 'https') }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/gh-repo-defaults/my-defaults/.github/workflows/scorecards.yml
+++ b/gh-repo-defaults/my-defaults/.github/workflows/scorecards.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # Disable credential persistence for security
           persist-credentials: false

--- a/multi-gitter/config.yaml
+++ b/multi-gitter/config.yaml
@@ -49,7 +49,6 @@ merge-type:
 platform: github
 
 # Pull request configuration
-draft: true
 pr-title: "chore: add default github repo files"
 pr-body: |
   This PR adds/updates standardized repository configuration files including:

--- a/multi-gitter/multi-gitter-run-script.sh
+++ b/multi-gitter/multi-gitter-run-script.sh
@@ -99,6 +99,10 @@ case "${REPOSITORY}" in
     copy_defaults "${GH_REPO_DEFAULTS_BASE}/ansible"
     megalinter_flavor all
     ;;
+  ruzickap/ansible-my_workstation)
+    copy_defaults "${GH_REPO_DEFAULTS_BASE}/ansible"
+    checkout_files .gitignore
+    ;;
   ruzickap/ansible-*)
     copy_defaults "${GH_REPO_DEFAULTS_BASE}/ansible"
     ;;


### PR DESCRIPTION
## What changed

**Dependency bumps**
- `actions/checkout` → v7.0.0 across all workflows (root + `gh-repo-defaults`)
- `commit-check/commit-check-action` → v2.9.0
- pre-commit hooks: `pre-commit-terraform` v1.107.0, `rumdl` v0.2.20, `keep-sorted` v0.9.0, `commitizen` v4.16.3, `commit-check` v2.8.0
- latex devcontainer `docker-in-docker` feature → v3

**Config changes**
- Add `REPOSITORY_KINGFISHER_ARGUMENTS: --exclude .git` to the ansible mega-linter defaults to avoid false-positive secret matches on Git metadata
- Add a dedicated `ruzickap/ansible-my_workstation` case to `multi-gitter-run-script.sh` (copies ansible defaults + checks out `.gitignore`)
- Drop `draft: true` from `multi-gitter/config.yaml` so distributed PRs open ready for review

## Why

Routine tooling/dependency maintenance plus small refinements to the multi-gitter distribution behavior. Changes to `gh-repo-defaults/` propagate to downstream repos on the next multi-gitter run.

## Notes

Shared config files were updated in both their root copy and the `gh-repo-defaults/my-defaults/` copy where applicable to avoid drift.