### PR TITLE
feat: add MY_SLACK_APP_TOKEN secret to ruzickap.github.io repo

### DIFF
--- a/opentofu/cloudflare-github/aws.tf
+++ b/opentofu/cloudflare-github/aws.tf
@@ -94,6 +94,11 @@ data "aws_ssm_parameter" "github_ruzickap_ruzickap_github_io_actions_secrets_MY_
   with_decryption = true
 }
 
+data "aws_ssm_parameter" "github_ruzickap_ruzickap_github_io_actions_secrets_MY_SLACK_APP_TOKEN" {
+  name            = "/github/ruzickap/ruzickap.github.io/actions-secrets/MY_SLACK_APP_TOKEN"
+  with_decryption = true
+}
+
 data "aws_ssm_parameter" "github_ruzickap_ruzickap_github_io_actions_secrets_MY_SLACK_BOT_SIGNING_SECRET" {
   name            = "/github/ruzickap/ruzickap.github.io/actions-secrets/MY_SLACK_BOT_SIGNING_SECRET"
   with_decryption = true

--- a/opentofu/cloudflare-github/github-repositories.tf
+++ b/opentofu/cloudflare-github/github-repositories.tf
@@ -202,6 +202,7 @@ locals {
         "GOOGLE_CLIENT_SECRET"                = data.aws_ssm_parameter.github_ruzickap_ruzickap_github_io_actions_secrets_GOOGLE_CLIENT_SECRET.value
         # .github/workflows/docs-confluence-sync.yml
         "MY_ATLASSIAN_PERSONAL_TOKEN" = data.aws_ssm_parameter.github_ruzickap_ruzickap_github_io_actions_secrets_MY_ATLASSIAN_PERSONAL_TOKEN.value
+        "MY_SLACK_APP_TOKEN"          = data.aws_ssm_parameter.github_ruzickap_ruzickap_github_io_actions_secrets_MY_SLACK_APP_TOKEN.value
         "MY_SLACK_BOT_SIGNING_SECRET" = data.aws_ssm_parameter.github_ruzickap_ruzickap_github_io_actions_secrets_MY_SLACK_BOT_SIGNING_SECRET.value
         "MY_SLACK_BOT_TOKEN"          = data.aws_ssm_parameter.github_shared_actions_secrets_MY_SLACK_BOT_TOKEN.value
         # Needed by .github/workflows/post_tests.yml


### PR DESCRIPTION
## What changed

- Add a new SSM parameter data source for `MY_SLACK_APP_TOKEN` (`/github/ruzickap/ruzickap.github.io/actions-secrets/MY_SLACK_APP_TOKEN`).
- Wire the `MY_SLACK_APP_TOKEN` value into the `ruzickap.github.io` GitHub Actions repository secrets.

## Why

The `ruzickap.github.io` workflows need a Slack app token alongside the existing Slack bot signing secret and bot token.

## Notes

This touches live infrastructure via the `opentofu/cloudflare-github` module (CI applies on push to `main` / PRs labeled `tofu-apply`).