### PR TITLE
chore: update pre-commit hooks and renovate cron schedule

### DIFF
--- a/.github/workflows/renovate-global.yml
+++ b/.github/workflows/renovate-global.yml
@@ -10,7 +10,7 @@ on:
         type: boolean
         description: Dry-Run
   schedule:
-    - cron: 1 0-5 * * 4
+    - cron: 1 1 * * *
 
 env:
   # Enable dry-run mode based on the workflow input (https://docs.renovatebot.com/self-hosted-configuration/#dryrun)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
       - id: shellcheck
 
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.107.0
+    rev: v1.108.0
     hooks:
       - id: terraform_checkov
         # args:
@@ -60,7 +60,7 @@ repos:
           - --args=--version "~> 1.11"
 
   - repo: https://github.com/rvben/rumdl-pre-commit
-    rev: v0.2.20
+    rev: v0.2.23
     hooks:
       - id: rumdl-fmt
 
@@ -127,7 +127,7 @@ repos:
       - id: keep-sorted
 
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: v4.16.3
+    rev: v4.16.4
     hooks:
       - id: commitizen
         stages: [commit-msg]
@@ -135,7 +135,7 @@ repos:
         stages: [pre-push]
 
   - repo: https://github.com/commit-check/commit-check
-    rev: v2.8.0
+    rev: v2.9.0
     hooks:
       - id: check-message
       - id: check-branch
@@ -159,7 +159,7 @@ repos:
           ]
 
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: v1.25.2
+    rev: v1.26.1
     hooks:
       - id: zizmor
 


### PR DESCRIPTION
## Summary

Maintenance update covering two config changes:

- **Bump pre-commit hook revisions** in `.pre-commit-config.yaml`:
  - `pre-commit-terraform` v1.107.0 → v1.108.0
  - `rumdl-pre-commit` v0.2.20 → v0.2.23
  - `commitizen` v4.16.3 → v4.16.4
  - `commit-check` v2.8.0 → v2.9.0
  - `zizmor-pre-commit` v1.25.2 → v1.26.1
- **Change renovate-global schedule** in `.github/workflows/renovate-global.yml`
  from `1 0-5 * * 4` (hourly window on Thursdays) to `1 1 * * *` (daily at 01:01).

## Motivation

Keep pre-commit tooling current and run Renovate on a simpler daily cadence.