### PR TITLE
chore: update megalinter and switch to betterleaks

### DIFF
--- a/.github/workflows/mega-linter-repos.yml
+++ b/.github/workflows/mega-linter-repos.yml
@@ -123,7 +123,7 @@ jobs:
           persist-credentials: false
 
       - name: 💡 MegaLinter (${{ matrix.flavor }})
-        uses: oxsecurity/megalinter@0e3ce9b9c8c10effb9b269509cc47ca17cae31c7 # v9.5.0
+        uses: oxsecurity/megalinter@ef3e84b8b836d76db562d0f3ed7da61e8fd538bc # v9.6.0
         env:
           GITHUB_TOKEN: ${{ github.token }}
           MEGALINTER_FLAVOR: ${{ matrix.flavor }}

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -63,7 +63,7 @@ jobs:
           fi
 
       - name: 💡 MegaLinter
-        uses: oxsecurity/megalinter@0e3ce9b9c8c10effb9b269509cc47ca17cae31c7 # v9.5.0
+        uses: oxsecurity/megalinter@ef3e84b8b836d76db562d0f3ed7da61e8fd538bc # v9.6.0
         env:
           GITHUB_COMMENT_REPORTER: false
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -23,12 +23,7 @@ BASH_SHFMT_ARGUMENTS: --case-indent --indent 2 --space-redirects
 DISABLE_LINTERS:
   - MARKDOWN_MARKDOWNLINT # Using rumdl instead (faster Rust-based alternative)
   - MARKDOWN_MARKDOWN_LINK_CHECK # Using lychee instead for link checking (more configurable)
-  - REPOSITORY_OSV_SCANNER # No package sources in this repo
   - SPELL_CSPELL # Spell checking disabled - prone to false positives
-  - TERRAFORM_TERRASCAN # Hard to configure - no clear documentation of the config file format
-
-# Disable email reporting
-EMAIL_REPORTER: false
 
 # Fail the build if a required linter is missing from the Docker flavor
 FAIL_IF_MISSING_LINTER_IN_FLAVOR: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -88,10 +88,10 @@ repos:
       - id: alphabetize-codeowners
       - id: fix-smartquotes
 
-  - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.30.1
+  - repo: https://github.com/betterleaks/betterleaks
+    rev: v1.6.0
     hooks:
-      - id: gitleaks
+      - id: betterleaks
 
   - repo: https://github.com/scop/pre-commit-shfmt
     rev: v3.13.1-1

--- a/gh-repo-defaults/ansible/.mega-linter.yml
+++ b/gh-repo-defaults/ansible/.mega-linter.yml
@@ -29,12 +29,7 @@ BASH_SHFMT_ARGUMENTS: --case-indent --indent 2 --space-redirects
 DISABLE_LINTERS:
   - MARKDOWN_MARKDOWNLINT # Using rumdl instead (faster Rust-based alternative)
   - MARKDOWN_MARKDOWN_LINK_CHECK # Using lychee instead for link checking (more configurable)
-  - REPOSITORY_OSV_SCANNER # No package sources in this repo - causes false failures
   - SPELL_CSPELL # Spell checking disabled - prone to false positives
-  - TERRAFORM_TERRASCAN # Hard to configure - no clear documentation of the config file format
-
-# Disable email reporting
-EMAIL_REPORTER: false
 
 # Fail the build if a required linter is missing from the Docker flavor
 FAIL_IF_MISSING_LINTER_IN_FLAVOR: true

--- a/gh-repo-defaults/my-defaults/.github/workflows/mega-linter.yml
+++ b/gh-repo-defaults/my-defaults/.github/workflows/mega-linter.yml
@@ -63,7 +63,7 @@ jobs:
           fi
 
       - name: 💡 MegaLinter
-        uses: oxsecurity/megalinter/flavors/documentation@0e3ce9b9c8c10effb9b269509cc47ca17cae31c7 # v9.5.0
+        uses: oxsecurity/megalinter/flavors/documentation@ef3e84b8b836d76db562d0f3ed7da61e8fd538bc # v9.6.0
         env:
           GITHUB_COMMENT_REPORTER: false
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/gh-repo-defaults/my-defaults/.mega-linter.yml
+++ b/gh-repo-defaults/my-defaults/.mega-linter.yml
@@ -23,12 +23,7 @@ BASH_SHFMT_ARGUMENTS: --case-indent --indent 2 --space-redirects
 DISABLE_LINTERS:
   - MARKDOWN_MARKDOWNLINT # Using rumdl instead (faster Rust-based alternative)
   - MARKDOWN_MARKDOWN_LINK_CHECK # Using lychee instead for link checking (more configurable)
-  - REPOSITORY_OSV_SCANNER # No package sources in this repo
   - SPELL_CSPELL # Spell checking disabled - prone to false positives
-  - TERRAFORM_TERRASCAN # Hard to configure - no clear documentation of the config file format
-
-# Disable email reporting
-EMAIL_REPORTER: false
 
 # Fail the build if a required linter is missing from the Docker flavor
 FAIL_IF_MISSING_LINTER_IN_FLAVOR: true


### PR DESCRIPTION
## What changed

- **MegaLinter** bumped from `v9.5.0` → `v9.6.0` across all workflows
  (`.github/workflows/mega-linter.yml`, `mega-linter-repos.yml`, and the
  `my-defaults` copy).
- **gitleaks → betterleaks**: replaced the `gitleaks` pre-commit hook
  (`v8.30.1`) with `betterleaks` (`v1.6.0`).
- **Linter config cleanup** in `.mega-linter.yml`:
  - Re-enabled `REPOSITORY_OSV_SCANNER` and `TERRAFORM_TERRASCAN` (removed
    from `DISABLE_LINTERS`).
  - Dropped the `EMAIL_REPORTER: false` override to fall back to default
    behavior.

## Why

Keep linting tooling current and drop overrides that are no longer needed.
Changes are mirrored into `gh-repo-defaults/my-defaults` and
`gh-repo-defaults/ansible` so downstream repos stay in sync on the next
multi-gitter run.