### PR TITLE
chore: update actions, pre-commit hooks, and linter config

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,13 +32,13 @@ jobs:
 
       - name: Initialize CodeQL
         # Does not support arm64
-        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           languages: actions
           build-mode: none
           queries: security-extended
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           category: "/language:actions"

--- a/.github/workflows/pr-slack-notification.yml
+++ b/.github/workflows/pr-slack-notification.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Post PR summary message to slack
         id: message
-        uses: slackapi/slack-github-action@0d95c9a7becc1e6e297d76df9bc735c44f4cbcbc # v3.0.5
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         with:
           method: chat.postMessage
           token: ${{ secrets.MY_SLACK_BOT_TOKEN }}
@@ -116,7 +116,7 @@ jobs:
 
       - name: React to PR summary message in slack with emoji
         if: ${{ steps.slack-timestamp.outputs.github_event_pull_request_html_url == 'true' && env.EMOJI != 'false' }}
-        uses: slackapi/slack-github-action@0d95c9a7becc1e6e297d76df9bc735c44f4cbcbc # v3.0.5
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         with:
           method: reactions.add
           token: ${{ secrets.MY_SLACK_BOT_TOKEN }}
@@ -127,7 +127,7 @@ jobs:
 
       - name: Update the original message with status Merged ✅
         if: ${{ github.event.pull_request.merged && steps.slack-timestamp.outputs.github_event_pull_request_html_url == 'true' }}
-        uses: slackapi/slack-github-action@0d95c9a7becc1e6e297d76df9bc735c44f4cbcbc # v3.0.5
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         with:
           method: chat.update
           token: ${{ secrets.MY_SLACK_BOT_TOKEN }}
@@ -144,7 +144,7 @@ jobs:
 
       - name: Update the original message with status Closed ❎
         if: ${{ github.event.action == 'closed' && github.event.pull_request.merged == false && steps.slack-timestamp.outputs.github_event_pull_request_html_url == 'true' }}
-        uses: slackapi/slack-github-action@0d95c9a7becc1e6e297d76df9bc735c44f4cbcbc # v3.0.5
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         with:
           method: chat.update
           token: ${{ secrets.MY_SLACK_BOT_TOKEN }}

--- a/.github/workflows/pre-commit-config.yml
+++ b/.github/workflows/pre-commit-config.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: 1.26
 

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -40,7 +40,7 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF results to GitHub Security
-        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           sarif_file: results.sarif
           # Set category to distinguish from other security scans

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -21,7 +21,6 @@ BASH_SHFMT_ARGUMENTS: --case-indent --indent 2 --space-redirects
 
 # Disable linters
 DISABLE_LINTERS:
-  - MARKDOWN_MARKDOWNLINT # Using rumdl instead (faster Rust-based alternative)
   - MARKDOWN_MARKDOWN_LINK_CHECK # Using lychee instead for link checking (more configurable)
   - SPELL_CSPELL # Spell checking disabled - prone to false positives
   - TERRAFORM_TERRASCAN # Disabled - using checkov and trivy for IaC security scanning
@@ -41,11 +40,17 @@ JSON_JSONLINT_ARGUMENTS: --comments
 # Exclude devcontainer.json from JSON linting (VS Code extension format)
 JSON_JSONLINT_FILTER_REGEX_EXCLUDE: .devcontainer/devcontainer.json
 
+# Use rumdl as the default Markdown style (faster Rust-based alternative)
+MARKDOWN_DEFAULT_STYLE: rumdl
+
 # Exclude CHANGELOG.md from rumdl (auto-generated, may have formatting issues)
 MARKDOWN_RUMDL_FILTER_REGEX_EXCLUDE: CHANGELOG.md
 
 # Disable the MegaLinter ASCII art graphic in output
 PRINT_ALPACA: false
+
+# Use ruff as the default Python style (faster Rust-based alternative)
+PYTHON_DEFAULT_STYLE: ruff
 
 # Don't create a report output folder (using CI artifacts instead)
 REPORT_OUTPUT_FOLDER: none

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,7 +53,7 @@ repos:
       - id: betterleaks-system
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.2
+    rev: v2.4.3
     hooks:
       - id: codespell
 
@@ -119,7 +119,7 @@ repos:
       - id: actionlint-system
 
   - repo: https://github.com/rvben/rumdl-pre-commit
-    rev: v0.2.30
+    rev: v0.2.35
     hooks:
       - id: rumdl-fmt
 
@@ -146,7 +146,7 @@ repos:
       - id: alphabetize-codeowners
 
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: v1.26.1
+    rev: v1.27.0
     hooks:
       - id: zizmor
   # keep-sorted end

--- a/gh-repo-defaults/ansible/.mega-linter.yml
+++ b/gh-repo-defaults/ansible/.mega-linter.yml
@@ -27,7 +27,6 @@ BASH_SHFMT_ARGUMENTS: --case-indent --indent 2 --space-redirects
 
 # Disable linters
 DISABLE_LINTERS:
-  - MARKDOWN_MARKDOWNLINT # Using rumdl instead (faster Rust-based alternative)
   - MARKDOWN_MARKDOWN_LINK_CHECK # Using lychee instead for link checking (more configurable)
   - SPELL_CSPELL # Spell checking disabled - prone to false positives
   - TERRAFORM_TERRASCAN # Disabled - using checkov and trivy for IaC security scanning
@@ -47,11 +46,17 @@ JSON_JSONLINT_ARGUMENTS: --comments
 # Exclude devcontainer.json from JSON linting (VS Code extension format)
 JSON_JSONLINT_FILTER_REGEX_EXCLUDE: .devcontainer/devcontainer.json
 
+# Use rumdl as the default Markdown style (faster Rust-based alternative)
+MARKDOWN_DEFAULT_STYLE: rumdl
+
 # Exclude CHANGELOG.md from rumdl (auto-generated, may have formatting issues)
 MARKDOWN_RUMDL_FILTER_REGEX_EXCLUDE: CHANGELOG.md
 
 # Disable the MegaLinter ASCII art graphic in output
 PRINT_ALPACA: false
+
+# Use ruff as the default Python style (faster Rust-based alternative)
+PYTHON_DEFAULT_STYLE: ruff
 
 # Don't create a report output folder (using CI artifacts instead)
 REPORT_OUTPUT_FOLDER: none

--- a/gh-repo-defaults/my-defaults/.github/workflows/codeql.yml
+++ b/gh-repo-defaults/my-defaults/.github/workflows/codeql.yml
@@ -32,13 +32,13 @@ jobs:
 
       - name: Initialize CodeQL
         # Does not support arm64
-        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           languages: actions
           build-mode: none
           queries: security-extended
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           category: "/language:actions"

--- a/gh-repo-defaults/my-defaults/.github/workflows/pr-slack-notification.yml
+++ b/gh-repo-defaults/my-defaults/.github/workflows/pr-slack-notification.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Post PR summary message to slack
         id: message
-        uses: slackapi/slack-github-action@0d95c9a7becc1e6e297d76df9bc735c44f4cbcbc # v3.0.5
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         with:
           method: chat.postMessage
           token: ${{ secrets.MY_SLACK_BOT_TOKEN }}
@@ -116,7 +116,7 @@ jobs:
 
       - name: React to PR summary message in slack with emoji
         if: ${{ steps.slack-timestamp.outputs.github_event_pull_request_html_url == 'true' && env.EMOJI != 'false' }}
-        uses: slackapi/slack-github-action@0d95c9a7becc1e6e297d76df9bc735c44f4cbcbc # v3.0.5
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         with:
           method: reactions.add
           token: ${{ secrets.MY_SLACK_BOT_TOKEN }}
@@ -127,7 +127,7 @@ jobs:
 
       - name: Update the original message with status Merged ✅
         if: ${{ github.event.pull_request.merged && steps.slack-timestamp.outputs.github_event_pull_request_html_url == 'true' }}
-        uses: slackapi/slack-github-action@0d95c9a7becc1e6e297d76df9bc735c44f4cbcbc # v3.0.5
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         with:
           method: chat.update
           token: ${{ secrets.MY_SLACK_BOT_TOKEN }}
@@ -144,7 +144,7 @@ jobs:
 
       - name: Update the original message with status Closed ❎
         if: ${{ github.event.action == 'closed' && github.event.pull_request.merged == false && steps.slack-timestamp.outputs.github_event_pull_request_html_url == 'true' }}
-        uses: slackapi/slack-github-action@0d95c9a7becc1e6e297d76df9bc735c44f4cbcbc # v3.0.5
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         with:
           method: chat.update
           token: ${{ secrets.MY_SLACK_BOT_TOKEN }}

--- a/gh-repo-defaults/my-defaults/.github/workflows/scorecards.yml
+++ b/gh-repo-defaults/my-defaults/.github/workflows/scorecards.yml
@@ -40,7 +40,7 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF results to GitHub Security
-        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           sarif_file: results.sarif
           # Set category to distinguish from other security scans

--- a/gh-repo-defaults/my-defaults/.mega-linter.yml
+++ b/gh-repo-defaults/my-defaults/.mega-linter.yml
@@ -21,7 +21,6 @@ BASH_SHFMT_ARGUMENTS: --case-indent --indent 2 --space-redirects
 
 # Disable linters
 DISABLE_LINTERS:
-  - MARKDOWN_MARKDOWNLINT # Using rumdl instead (faster Rust-based alternative)
   - MARKDOWN_MARKDOWN_LINK_CHECK # Using lychee instead for link checking (more configurable)
   - SPELL_CSPELL # Spell checking disabled - prone to false positives
   - TERRAFORM_TERRASCAN # Disabled - using checkov and trivy for IaC security scanning
@@ -41,11 +40,17 @@ JSON_JSONLINT_ARGUMENTS: --comments
 # Exclude devcontainer.json from JSON linting (VS Code extension format)
 JSON_JSONLINT_FILTER_REGEX_EXCLUDE: .devcontainer/devcontainer.json
 
+# Use rumdl as the default Markdown style (faster Rust-based alternative)
+MARKDOWN_DEFAULT_STYLE: rumdl
+
 # Exclude CHANGELOG.md from rumdl (auto-generated, may have formatting issues)
 MARKDOWN_RUMDL_FILTER_REGEX_EXCLUDE: CHANGELOG.md
 
 # Disable the MegaLinter ASCII art graphic in output
 PRINT_ALPACA: false
+
+# Use ruff as the default Python style (faster Rust-based alternative)
+PYTHON_DEFAULT_STYLE: ruff
 
 # Don't create a report output folder (using CI artifacts instead)
 REPORT_OUTPUT_FOLDER: none

--- a/opentofu/cloudflare-github/github-repositories.tf
+++ b/opentofu/cloudflare-github/github-repositories.tf
@@ -15,6 +15,12 @@ locals {
       visibility  = "private"
       topics      = ["ai", "ai-security", "caisp", "caisp-exam", "caisp-exam-preparation", "devsecops", "notes", "security"]
     }
+    "claude_courses" = {
+      name        = "claude-courses"
+      description = "Claude Courses Notes"
+      visibility  = "public"
+      topics      = ["claude", "courses", "architect", "foundations", "notes", "public"]
+    }
     "container_image_scans" = {
       name        = "container-image-scans"
       description = "Container image scans"


### PR DESCRIPTION
## Summary

Routine maintenance bumps for pinned GitHub Actions, pre-commit hooks, and
MegaLinter configuration, plus a new managed GitHub repository.

## Changes

- **GitHub Actions** (root + `gh-repo-defaults`):
  - `github/codeql-action` v4.37.0 → v4.37.1
  - `commit-check/commit-check-action` v2.11.0 → v2.11.1
  - `slackapi/slack-github-action` v3.0.x → v4.0.0
  - `actions/setup-go` v6.5.0 → v7.0.0
  - `astral-sh/setup-uv` v8.3.0 → v8.3.2
  - `renovatebot/github-action` v46.1.18 → v46.1.19
  - `actions/stale` v10.3.0 → v10.4.0
  - `lycheeverse/lychee-action` v2.8.0 → v2.9.0 (hugo defaults)
- **Pre-commit hooks**: codespell v2.4.3, rumdl v0.2.35, zizmor v1.27.0
- **MegaLinter config**: re-enable markdownlint via `MARKDOWN_DEFAULT_STYLE: rumdl`
  and set `PYTHON_DEFAULT_STYLE: ruff` (root, `my-defaults`, `ansible`)
- **OpenTofu**: add `claude-courses` public repository to
  `opentofu/cloudflare-github/github-repositories.tf`

## Notes

Shared config changes are mirrored in both the root copies and
`gh-repo-defaults/my-defaults/` to avoid drift.