### PR TITLE
ci: run renovate-global cron at 01:01 and 02:01

### DIFF
--- a/.github/workflows/renovate-global.yml
+++ b/.github/workflows/renovate-global.yml
@@ -10,7 +10,7 @@ on:
         type: boolean
         description: Dry-Run
   schedule:
-    - cron: 1 1 * * *
+    - cron: 1 1,2 * * *
 
 env:
   # Enable dry-run mode based on the workflow input (https://docs.renovatebot.com/self-hosted-configuration/#dryrun)


### PR DESCRIPTION
## What

Add a second scheduled run to the `renovate-global` workflow so it runs at both **01:01** and **02:01** instead of only once at 01:01.

```diff
-    - cron: 1 1 * * *
+    - cron: 1 1,2 * * *
```

## Why

Running Renovate a second time an hour later gives it another opportunity to pick up and process dependency updates each day.

> Note: `1,2 1 * * *` (two runs 1 minute apart) was rejected by `actionlint` for violating the 5-minute minimum interval, so the runs are spaced one hour apart via `1 1,2 * * *`.