### PR TITLE
fix: escape dot in CHANGELOG.md megalinter exclude regex

### DIFF
--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -29,7 +29,7 @@ DISABLE_LINTERS:
 FAIL_IF_MISSING_LINTER_IN_FLAVOR: true
 
 # Exclude CHANGELOG.md from all linting
-FILTER_REGEX_EXCLUDE: CHANGELOG.md
+FILTER_REGEX_EXCLUDE: CHANGELOG\.md
 
 # Allow formatters to report errors
 FORMATTERS_DISABLE_ERRORS: false
@@ -44,7 +44,7 @@ JSON_JSONLINT_FILTER_REGEX_EXCLUDE: .devcontainer/devcontainer.json
 MARKDOWN_DEFAULT_STYLE: rumdl
 
 # Exclude CHANGELOG.md from rumdl (auto-generated, may have formatting issues)
-MARKDOWN_RUMDL_FILTER_REGEX_EXCLUDE: CHANGELOG.md
+MARKDOWN_RUMDL_FILTER_REGEX_EXCLUDE: CHANGELOG\.md
 
 # Disable the MegaLinter ASCII art graphic in output
 PRINT_ALPACA: false

--- a/gh-repo-defaults/ansible/.mega-linter.yml
+++ b/gh-repo-defaults/ansible/.mega-linter.yml
@@ -35,7 +35,7 @@ DISABLE_LINTERS:
 FAIL_IF_MISSING_LINTER_IN_FLAVOR: true
 
 # Exclude CHANGELOG.md from all linting
-FILTER_REGEX_EXCLUDE: CHANGELOG.md
+FILTER_REGEX_EXCLUDE: CHANGELOG\.md
 
 # Allow formatters to report errors
 FORMATTERS_DISABLE_ERRORS: false
@@ -50,7 +50,7 @@ JSON_JSONLINT_FILTER_REGEX_EXCLUDE: .devcontainer/devcontainer.json
 MARKDOWN_DEFAULT_STYLE: rumdl
 
 # Exclude CHANGELOG.md from rumdl (auto-generated, may have formatting issues)
-MARKDOWN_RUMDL_FILTER_REGEX_EXCLUDE: CHANGELOG.md
+MARKDOWN_RUMDL_FILTER_REGEX_EXCLUDE: CHANGELOG\.md
 
 # Disable the MegaLinter ASCII art graphic in output
 PRINT_ALPACA: false

--- a/gh-repo-defaults/my-defaults/.mega-linter.yml
+++ b/gh-repo-defaults/my-defaults/.mega-linter.yml
@@ -29,7 +29,7 @@ DISABLE_LINTERS:
 FAIL_IF_MISSING_LINTER_IN_FLAVOR: true
 
 # Exclude CHANGELOG.md from all linting
-FILTER_REGEX_EXCLUDE: CHANGELOG.md
+FILTER_REGEX_EXCLUDE: CHANGELOG\.md
 
 # Allow formatters to report errors
 FORMATTERS_DISABLE_ERRORS: false
@@ -44,7 +44,7 @@ JSON_JSONLINT_FILTER_REGEX_EXCLUDE: .devcontainer/devcontainer.json
 MARKDOWN_DEFAULT_STYLE: rumdl
 
 # Exclude CHANGELOG.md from rumdl (auto-generated, may have formatting issues)
-MARKDOWN_RUMDL_FILTER_REGEX_EXCLUDE: CHANGELOG.md
+MARKDOWN_RUMDL_FILTER_REGEX_EXCLUDE: CHANGELOG\.md
 
 # Disable the MegaLinter ASCII art graphic in output
 PRINT_ALPACA: false


### PR DESCRIPTION
## What changed

Escape the dot in the `CHANGELOG.md` exclude patterns so they are treated as literal filenames rather than regex wildcards:

- `FILTER_REGEX_EXCLUDE: CHANGELOG.md` → `CHANGELOG\.md`
- `MARKDOWN_RUMDL_FILTER_REGEX_EXCLUDE: CHANGELOG.md` → `CHANGELOG\.md`

## Why

These values are regular expressions. The unescaped `.` matches *any* character, so patterns like `CHANGELOGxmd` would also match. Escaping restricts the pattern to the literal `CHANGELOG.md` file.

## Scope

Applied to the root config and both `gh-repo-defaults/` copies to keep the dogfooded defaults in sync.