### PR TITLE
ci: use feat bump for MegaLinter in custom flavor repo

### DIFF
--- a/.github/renovate-global.json5
+++ b/.github/renovate-global.json5
@@ -189,6 +189,15 @@
       enabled: false,
     },
     {
+      // Bump must be "feat" so release-please opens a release PR; merging it
+      // publishes a Release that triggers the custom flavor image build.
+      description: "MegaLinter bump must be feat so release-please releases it",
+      matchRepositories: ["ruzickap/megalinter-custom-flavor-my-repos"],
+      matchDepNames: ["oxsecurity/megalinter"],
+      commitMessageTopic: "MegaLinter",
+      semanticCommitType: "feat",
+    },
+    {
       description: "Skip renovating _posts directory in ruzickap.github.io",
       matchRepositories: ["ruzickap/ruzickap.github.io"],
       matchFileNames: ["_posts/**"],


### PR DESCRIPTION
## What

Add a Renovate package rule so MegaLinter (`oxsecurity/megalinter`)
updates in `ruzickap/megalinter-custom-flavor-my-repos` are committed as
`feat` instead of the default type.

## Why

The bump must be a `feat` commit so that release-please opens a release
PR. Merging that release PR publishes a GitHub Release, which in turn
triggers the custom flavor image build.