### PR TITLE
ci: run renovate-global cron at 00:00 and 08:00

### DIFF
--- a/.github/workflows/renovate-global.yml
+++ b/.github/workflows/renovate-global.yml
@@ -10,7 +10,7 @@ on:
         type: boolean
         description: Dry-Run
   schedule:
-    - cron: 1 1,2 * * *
+    - cron: 0 0,8 * * *
 
 env:
   # Enable dry-run mode based on the workflow input (https://docs.renovatebot.com/self-hosted-configuration/#dryrun)


### PR DESCRIPTION
## What

Change the `renovate-global` workflow schedule from `1 1,2 * * *` to `0 0,8 * * *`.

## Why

Spread the two daily Renovate runs further apart (midnight and 08:00 UTC) instead of clustering them at 01:01 and 02:01.